### PR TITLE
docs: add module-level CLAUDE.md for all modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,150 @@ test/
 - **Setter injection** with `assert()` guards — all wiring in `main.cpp`
 - **Effects** are decoupled from hardware via `IPixelCanvas` interface
 - DisplayManager is split into 3 classes: `DisplayManager_` (coordinator) + `DisplayRenderer_` + `NotificationManager_`
-- Each module directory has a `README.md` with detailed AI reference — read it before modifying that module
+- Each module directory has a `CLAUDE.md` or `README.md` with detailed AI reference — read it before modifying that module
+
+## Module Dependency Graph
+
+All inter-module communication goes through interfaces wired in `main.cpp`.
+
+### Modules and their roles
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ main.cpp — Composition Root                                         │
+│ Creates singletons, wires all interfaces, runs setup() + loop()    │
+└─────────────────────────────────────────────────────────────────────┘
+         │ wires interfaces to:
+         ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                        CORE MODULES                                  │
+│                                                                      │
+│  DisplayManager_ ─────────── "the brain"                            │
+│  ├── DisplayRenderer_         draws text, shapes, charts, images    │
+│  ├── NotificationManager_     notification queue + 3 indicators     │
+│  └── MatrixDisplayUi          app framework, transitions, overlays  │
+│       └── NeoMatrixCanvas     IPixelCanvas for effects              │
+│                                                                      │
+│  MQTTManager_ ────────────── MQTT broker + Home Assistant (25 HA)   │
+│  ServerManager_ ──────────── HTTP REST API (33 endpoints)           │
+│  PeripheryManager_ ───────── sensors, buzzer, buttons, LDR, battery │
+│  MenuManager_ ────────────── on-device settings menu                │
+│  PowerManager_ ───────────── deep sleep / wake                      │
+│  UpdateManager_ ──────────── OTA firmware updates                   │
+│  DataFetcher_ ────────────── external HTTP data sources             │
+│  GameManager_ ────────────── games (disabled by default)            │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│                        LIBRARIES                                     │
+│                                                                      │
+│  lib/interfaces/     13 pure virtual interfaces (decoupling layer)  │
+│  lib/services/       12 stateless utilities (100% test coverage)    │
+│  lib/config/         ConfigTypes — all config structs               │
+│  lib/home-assistant-integration/   ArduinoHA v2.0.0 (trimmed)      │
+│  lib/webserver/      ESPAsyncWebServer wrapper + HTML pages         │
+│  lib/TJpg_Decoder/   JPEG decoder (local fork)                     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Interface wiring (main.cpp)
+
+Who provides what interface to whom:
+
+```
+                     PROVIDES                    CONSUMES
+Module               Interface           →       Module
+─────────────────────────────────────────────────────────────
+DisplayManager_      IDisplayControl     →       MenuManager, ServerManager, MQTTManager
+DisplayManager_      IDisplayNavigation  →       MenuManager, ServerManager, MQTTManager, DataFetcher
+DisplayManager_      IMatrixHost         →       MatrixDisplayUi
+DisplayManager_      IButtonHandler      →       PeripheryManager (dispatcher)
+DisplayRenderer_     IDisplayRenderer    →       UpdateManager, GameManager, MenuManager, ServerManager
+NotificationManager_ IDisplayNotifier   →       ServerManager, MQTTManager
+MQTTManager_         INotifier           →       DisplayManager, NotificationManager
+MQTTManager_         IButtonReporter     →       PeripheryManager (dispatcher)
+ServerManager_       IButtonReporter     →       PeripheryManager (dispatcher)
+PeripheryManager_    IPeripheryProvider  →       DisplayManager, NotificationManager, MenuManager, MQTTManager
+PeripheryManager_    ISound              →       ServerManager, MQTTManager
+PowerManager_        IPower              →       ServerManager, MQTTManager
+UpdateManager_       IUpdater            →       ServerManager, MQTTManager, MenuManager
+NeoMatrixCanvas      IPixelCanvas        →       Effect system (19 effects)
+MenuManager_         IButtonHandler      →       PeripheryManager (dispatcher)
+```
+
+### Data flow diagram
+
+```
+     ┌──────────┐         ┌──────────────┐        ┌─────────────┐
+     │  Buttons  │────────▶│PeripheryMgr  │───────▶│ DisplayMgr  │
+     │  LDR     │ hardware│ (IButtonHandler│ iface │ (IDisplayCtrl│
+     │  Sensors │ events  │  ISound       │───┐   │  IDisplayNav)│
+     └──────────┘         │  IPeriphProv) │   │   └──────┬───────┘
+                          └──────────────┘   │          │
+                                │            │          │ owns
+                                │            │   ┌──────▼───────┐
+          ┌─────────────┐       │            │   │MatrixDisplayUi│
+          │ MQTT Broker │◀─────▶│            │   │(state machine,│
+          │ (Home Asst) │ iface │            │   │ transitions)  │
+          └──────┬──────┘       │            │   └──────┬───────┘
+                 │         ┌────▼──────┐     │          │ renders
+                 └────────▶│MQTTManager│     │   ┌──────▼───────┐
+                           │(INotifier │─────┘   │DisplayRenderer│
+                           │ IButtonRep│         │(IDisplayRender)│
+                           └───────────┘         └──────┬───────┘
+                                                        │
+          ┌─────────────┐                        ┌──────▼───────┐
+          │  HTTP Client │◀─────────────────────▶│ ServerManager │
+          │  (REST API)  │  33 endpoints          │(IButtonRep)  │
+          └─────────────┘                        └──────────────┘
+
+          ┌─────────────┐                        ┌──────────────┐
+          │  LED Matrix  │◀──────────────────────│    FastLED    │
+          │  32x8 WS2812│  256 pixels             │  NeoMatrix   │
+          └─────────────┘                        └──────────────┘
+```
+
+### Main loop execution order
+
+```cpp
+void loop() {
+    timer_tick();              // Background timers
+    ServerManager.tick();      // Process HTTP requests
+    DisplayManager.tick();     // Render current app/notification/effect
+    PeripheryManager.tick();   // Read sensors, buttons, update brightness
+    if (ServerManager.isConnected) {
+        MQTTManager.tick();    // Process MQTT messages, publish stats
+        DataFetcher.tick();    // Fetch external data sources
+    }
+}
+```
+
+### Service consumption map
+
+Which `lib/services/` each module uses:
+
+```
+DisplayManager  ← ColorUtils, TimeEffects, GammaUtils, TextUtils, StatsBuilder, OverlayMapping
+DisplayRenderer ← TextUtils, UnicodeFont, ColorUtils
+PeripheryManager← SensorCalc
+MQTTManager     ← MessageRouter, HADiscovery, AppRegistry, StatsBuilder, PlaceholderUtils
+Apps            ← ColorUtils, TimeEffects, TextUtils
+main.cpp        ← TextUtils (setTextFont at startup)
+```
+
+### CLAUDE.md reference map
+
+Each module has detailed AI documentation:
+
+```
+CLAUDE.md (root)                            ← you are here
+├── lib/interfaces/CLAUDE.md                ← 13 interfaces, methods, implementors, consumers
+├── lib/services/CLAUDE.md                  ← 12 services, API, deps, test mapping
+├── lib/home-assistant-integration/CLAUDE.md← ArduinoHA fork, 7/17 entity types enabled
+├── src/DisplayManager/CLAUDE.md            ← 3 classes, 9 files, rendering, custom apps
+├── src/MQTTManager/CLAUDE.md               ← 25 HA entities, 20 topics, 7 callbacks
+└── src/MatrixDisplayUi/CLAUDE.md           ← state machine, 10 transitions, indicators
+```
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,12 +190,27 @@ Each module has detailed AI documentation:
 
 ```
 CLAUDE.md (root)                            ← you are here
+│
 ├── lib/interfaces/CLAUDE.md                ← 13 interfaces, methods, implementors, consumers
 ├── lib/services/CLAUDE.md                  ← 12 services, API, deps, test mapping
+├── lib/config/CLAUDE.md                    ← 13 config structs, all fields, defaults, persistence
 ├── lib/home-assistant-integration/CLAUDE.md← ArduinoHA fork, 7/17 entity types enabled
+├── lib/webserver/CLAUDE.md                 ← FSWebServer, WiFi, routes, HTML pipeline
+│
+├── src/CLAUDE.md                           ← standalone modules: ServerManager (33 endpoints),
+│                                              PeripheryManager (buttons, sensors, buzzer),
+│                                              MenuManager (13 menu items), UpdateManager (OTA),
+│                                              PowerManager (deep sleep), Globals (config store),
+│                                              AppContentRenderer (shared rendering pipeline)
 ├── src/DisplayManager/CLAUDE.md            ← 3 classes, 9 files, rendering, custom apps
 ├── src/MQTTManager/CLAUDE.md               ← 25 HA entities, 20 topics, 7 callbacks
-└── src/MatrixDisplayUi/CLAUDE.md           ← state machine, 10 transitions, indicators
+├── src/MatrixDisplayUi/CLAUDE.md           ← state machine, 10 transitions, indicators
+├── src/DataFetcher/CLAUDE.md               ← external HTTP data sources, round-robin polling
+│
+├── src/Apps/README.md                      ← native + custom app rendering
+├── src/Games/README.md                     ← GameManager, SlotMachine, SvitrixSays
+├── src/MelodyPlayer/README.md              ← RTTTL parser, async PWM playback
+└── src/effects/README.md                   ← 19 visual effects, weather overlays, IPixelCanvas
 ```
 
 ## Coding Conventions
@@ -227,6 +242,71 @@ CLAUDE.md (root)                            ← you are here
 - Concise communication preferred
 - Always verify changes with build + tests
 
-## Git
+## Git & Release Workflow
+
+### Commit rules
 
 - Do NOT add `Co-Authored-By` lines to commit messages
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+  - `feat: add temperature overlay` — new feature
+  - `fix: correct MQTT reconnect loop` — bug fix
+  - `refactor: extract notification queue` — code restructuring
+  - `docs: update MQTTManager CLAUDE.md` — documentation only
+  - `test: add ColorUtils edge cases` — tests only
+  - `chore: bump ArduinoHA to 2.0.1` — maintenance, deps, CI
+  - `perf: reduce DisplayRenderer draw calls` — performance
+- Scope is optional but encouraged: `feat(mqtt): add light entity support`
+- Breaking changes: add `!` after type — `refactor!: rename INotifier methods`
+- Keep subject line under 72 characters
+- Body: explain **why**, not **what** (the diff shows what)
+
+### Branching strategy
+
+```
+main              ← always stable, every commit is a tagged release
+  └── feature/*   ← short-lived branches for features/fixes
+```
+
+- `main` is the single long-lived branch
+- All work happens in `feature/*` branches, merged via PR
+- No `develop` branch — keep it simple for solo/small team
+- Add `develop` + `release/*` branches only when contributors appear
+
+### Versioning — Semantic Versioning with pre-release tags
+
+Format: `vMAJOR.MINOR.PATCH[-pre.N]`
+
+```
+v0.2.0-beta.1    ← first beta (from feature branch or main)
+v0.2.0-beta.2    ← beta bug fixes
+v0.2.0-rc.1      ← release candidate (feature freeze, only bug fixes)
+v0.2.0-rc.2      ← critical fix in RC
+v0.2.0           ← stable release (merged to main)
+```
+
+- **MAJOR** — breaking API/MQTT/config changes
+- **MINOR** — new features, new HA entities, new effects
+- **PATCH** — bug fixes, performance improvements
+
+### Release process
+
+1. Create `feature/*` branch from `main`
+2. Develop and test (`pio run -e ulanzi && pio test -e native_test`)
+3. When ready for beta testing: tag `v0.X.0-beta.1` on the branch
+4. When feature-complete: tag `v0.X.0-rc.1` (only bug fixes after this)
+5. Merge PR to `main`, tag `v0.X.0` on main
+6. Create GitHub Release from tag, attach `firmware.bin`
+
+### GitHub Releases
+
+- **Stable** (`v0.2.0`) — full release, marked as "Latest"
+- **Beta** (`v0.2.0-beta.1`) — mark as **pre-release** on GitHub
+- **RC** (`v0.2.0-rc.1`) — mark as **pre-release** on GitHub
+- Attach `.pio/build/ulanzi/firmware.bin` to each release
+- Release notes: list changes grouped by type (Features, Fixes, Breaking)
+
+### Tags
+
+- Always use annotated tags: `git tag -a v0.2.0 -m "v0.2.0: short description"`
+- Push tags explicitly: `git push origin v0.2.0`
+- Never delete or move published tags

--- a/lib/config/CLAUDE.md
+++ b/lib/config/CLAUDE.md
@@ -1,0 +1,199 @@
+# Config Library — AI Reference
+
+Shared configuration structs consumed by all modules. Single header, no logic, no dependencies beyond Arduino `String`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/ConfigTypes.h` | 13 config structs + 1 enum, all POD-style with public fields |
+
+## Config Structs
+
+### AuthConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `user` | String | `""` | HTTP username |
+| `pass` | String | `"svitrix"` | HTTP password |
+
+### NetworkConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `isStatic` | bool | `false` | Use static IP |
+| `ip` | String | `"192.168.178.10"` | Static IP address |
+| `gateway` | String | `"192.168.178.1"` | Gateway |
+| `subnet` | String | `"255.255.255.0"` | Subnet mask |
+| `primaryDns` | String | `"8.8.8.8"` | Primary DNS |
+| `secondaryDns` | String | `"1.1.1.1"` | Secondary DNS |
+
+### BatteryConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `percent` | uint8_t | `0` | Calculated battery % |
+| `raw` | uint16_t | `0` | Current ADC reading |
+| `minRaw` | uint16_t | `475` | ADC value = 0% |
+| `maxRaw` | uint16_t | `665` | ADC value = 100% |
+
+### HaConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `discovery` | bool | `false` | Enable HA discovery |
+| `prefix` | String | `"homeassistant"` | HA discovery topic prefix |
+
+### MqttConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `host` | String | `""` | Broker hostname/IP |
+| `port` | uint16_t | `1883` | Broker port |
+| `user` | String | `""` | MQTT username |
+| `pass` | String | `""` | MQTT password |
+| `prefix` | String | `""` | Topic prefix (set to deviceId at runtime) |
+
+### SensorConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `currentTemp` | float | `0` | Current temperature reading |
+| `currentHum` | float | `0` | Current humidity reading |
+| `currentLux` | float | `0` | Current lux reading |
+| `ldrRaw` | uint16_t | `0` | Raw LDR ADC value |
+| `tempSensorType` | uint8_t | `TEMP_SENSOR_TYPE_NONE` | Detected sensor type |
+| `sensorReading` | bool | `true` | Enable sensor polling |
+| `sensorsStable` | bool | `false` | Sensors have stabilized |
+| `tempOffset` | float | `-9` | Temperature calibration offset |
+| `humOffset` | float | `0` | Humidity calibration offset |
+
+### TempSensorType (enum)
+
+| Value | Constant |
+|-------|----------|
+| 0 | `TEMP_SENSOR_TYPE_NONE` |
+| 1 | `TEMP_SENSOR_TYPE_BME280` |
+| 2 | `TEMP_SENSOR_TYPE_HTU21DF` |
+| 3 | `TEMP_SENSOR_TYPE_BMP280` |
+| 4 | `TEMP_SENSOR_TYPE_SHT31` |
+
+### DisplayConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `matrixLayout` | int | `0` | NeoMatrix layout flag |
+| `matrixFps` | uint8_t | `42` | Target FPS |
+| `matrixOff` | bool | `false` | Display powered off |
+| `mirrorDisplay` | bool | `false` | Mirror horizontally |
+| `rotateScreen` | bool | `false` | Rotate 180 degrees |
+| `uppercaseLetters` | bool | `true` | Force uppercase text |
+| `backgroundEffect` | int | `-1` | Active background effect index (-1 = none) |
+
+### BrightnessConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `brightness` | int | `120` | Current brightness (0-255) |
+| `brightnessPercent` | int | `0` | Brightness as percentage |
+| `autoBrightness` | bool | `true` | Enable LDR auto-brightness |
+| `minBrightness` | uint8_t | `2` | Auto-brightness floor |
+| `maxBrightness` | uint8_t | `160` | Auto-brightness ceiling |
+| `ldrGamma` | float | `3.0` | LDR gamma curve exponent |
+| `ldrFactor` | float | `1.0` | LDR scaling factor |
+| `ldrOnGround` | bool | `false` | LDR mounted on ground side |
+
+### ColorConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `textColor` | uint32_t | `0xFFFFFF` | Default text color (white) |
+| `timeColor` | uint32_t | `0` | Time app color (0 = use textColor) |
+| `dateColor` | uint32_t | `0` | Date app color |
+| `batColor` | uint32_t | `0` | Battery app color |
+| `tempColor` | uint32_t | `0` | Temperature app color |
+| `humColor` | uint32_t | `0` | Humidity app color |
+| `wdcActive` | uint32_t | `0xFFFFFF` | Weekday indicator active |
+| `wdcInactive` | uint32_t | `0x666666` | Weekday indicator inactive |
+| `calendarHeaderColor` | uint32_t | `0xFF0000` | Calendar header (red) |
+| `calendarTextColor` | uint32_t | `0x000000` | Calendar text (black) |
+| `calendarBodyColor` | uint32_t | `0xFFFFFF` | Calendar body (white) |
+
+### TimeConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `timeFormat` | String | `"%H:%M:%S"` | strftime format for time |
+| `dateFormat` | String | `"%d.%m.%y"` | strftime format for date |
+| `timeMode` | uint8_t | `1` | 0 = 12h, 1 = 24h |
+| `startOnMonday` | bool | `false` | Week starts on Monday |
+| `ntpServer` | String | `"de.pool.ntp.org"` | NTP server |
+| `ntpTz` | String | `"CET-1CEST,M3.5.0,M10.5.0/3"` | POSIX timezone |
+| `isCelsius` | bool | `false` | Temperature unit |
+| `tempDecimalPlaces` | int | `0` | Decimal places for temp display |
+
+### AppConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `showTime` | bool | `true` | Show time app |
+| `showDate` | bool | `true` | Show date app |
+| `showBat` | bool | `true` | Show battery app (Ulanzi only) |
+| `showTemp` | bool | `true` | Show temperature app |
+| `showHum` | bool | `true` | Show humidity app |
+| `showWeekday` | bool | `true` | Show weekday indicator |
+| `autoTransition` | bool | `false` | Auto-cycle through apps |
+| `transEffect` | int8_t | `1` | Transition effect index |
+| `timePerTransition` | int | `400` | Transition duration (ms) |
+| `timePerApp` | long | `7000` | Time per app before auto-transition (ms) |
+| `scrollSpeed` | uint8_t | `100` | Text scroll speed (ms per pixel) |
+| `blockNavigation` | bool | `false` | Block button navigation |
+
+### AudioConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `soundActive` | bool | `false` | Enable sound |
+| `soundVolume` | uint8_t | `30` | Volume level |
+| `bootSound` | String | `""` | RTTTL melody on boot |
+
+### SystemConfig
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `debugMode` | bool | `true` | Enable debug serial output |
+| `apTimeout` | uint32_t | `15` | AP mode timeout (seconds) |
+| `webPort` | int | `80` | HTTP server port |
+| `hostname` | String | `""` | mDNS hostname (set to deviceId) |
+| `updateCheck` | bool | `false` | Check for firmware updates |
+| `statsInterval` | long | `10000` | MQTT stats publish interval (ms) |
+| `newyear` | bool | `false` | New Year countdown mode |
+| `swapButtons` | bool | `false` | Swap left/right buttons |
+| `buttonCallback` | String | `""` | HTTP URL for button press callback |
+| `deviceId` | String | `""` | Unique device ID (from MAC) |
+| `updateAvailable` | bool | `false` | Runtime: OTA update available |
+| `apMode` | bool | `false` | Runtime: in AP mode |
+| `updateVersionUrl` | String | `""` | Custom update version check URL |
+| `updateFirmwareUrl` | String | `""` | Custom firmware download URL |
+
+## Persistence
+
+Config values come from **three layers** (later overrides earlier):
+
+1. **Compile-time defaults** — initializer lists in `Globals.cpp`
+2. **NVS (Preferences)** — `loadSettings()` / `saveSettings()` (namespace `"svitrix"`)
+3. **`/dev.json` (LittleFS)** — `loadDevSettings()` overrides (highest priority)
+
+## Who Uses What
+
+| Config Struct | Consumers |
+|---------------|-----------|
+| `appConfig` | DisplayManager, MQTTManager, ServerManager, MenuManager, Apps, MatrixDisplayUi |
+| `displayConfig` | DisplayManager, MQTTManager, ServerManager, MenuManager, DisplayRenderer |
+| `brightnessConfig` | DisplayManager, PeripheryManager, MQTTManager, ServerManager, MenuManager |
+| `colorConfig` | DisplayManager, DisplayRenderer, Apps, MQTTManager, ServerManager, MenuManager |
+| `timeConfig` | Apps, MQTTManager, ServerManager, MenuManager, Overlays |
+| `sensorConfig` | PeripheryManager, Apps, MQTTManager, ServerManager |
+| `systemConfig` | Nearly all modules |
+| `mqttConfig` | MQTTManager, ServerManager |
+| `audioConfig` | ServerManager, MQTTManager, MenuManager, PeripheryManager |
+| `batteryConfig` | PeripheryManager, Apps, MQTTManager |
+| `haConfig` | MQTTManager |
+| `networkConfig` | main.cpp (WiFi setup) |
+| `authConfig` | ServerManager |
+
+## Design Notes
+
+- Structs are plain C++ aggregates (no constructors, no methods)
+- All 13 instances declared `extern` in `Globals.h`, defined in `Globals.cpp`
+- Color fields use `uint32_t` (`0xRRGGBB`), not `CRGB` — avoids FastLED dependency
+- Some fields serve double duty as runtime state (e.g., `sensorConfig.currentTemp`)
+- Only dependency: `Arduino.h` (for `String` type)
+- Compiles in both `ulanzi` (ESP32) and `native_test` environments

--- a/lib/home-assistant-integration/CLAUDE.md
+++ b/lib/home-assistant-integration/CLAUDE.md
@@ -1,0 +1,88 @@
+# Home Assistant Integration — AI Reference
+
+Local fork of [arduino-home-assistant](https://github.com/dawidchyrzynski/arduino-home-assistant) v2.0.0 by Dawid Chyrzynski, trimmed for Svitrix.
+
+## What This Library Does
+
+MQTT-based Home Assistant auto-discovery. The device publishes config messages → HA auto-creates entities in its UI. Two-way: state reports (device → HA) + command callbacks (HA → device).
+
+## Enabled Entity Types (7 of 17)
+
+| Class | HA Type | Used For |
+|-------|---------|----------|
+| `HALight` | light | Matrix backlight, 3 indicator LEDs (brightness, RGB, color temp) |
+| `HASwitch` | switch | Auto-transition toggle |
+| `HAButton` | button | Dismiss, next/prev app, doUpdate |
+| `HASensor` | sensor | Battery, temp, humidity, lux, uptime, signal, version, RAM, current app, device ID, IP |
+| `HANumber` | number | Numeric settings with min/max/step |
+| `HASelect` | select | Brightness mode, transition effect dropdowns |
+| `HABinarySensor` | binary_sensor | 3 hardware buttons (left/mid/right) |
+
+10 types **excluded** via `EX_ARDUINOHA_*` defines in `ArduinoHADefines.h`: Camera, Cover, DeviceTracker, DeviceTrigger, Fan, HVAC, Lock, Scene, SensorNumber, TagScanner.
+
+## Class Hierarchy
+
+```
+HAMqtt (singleton, wraps PubSubClient)
+  └── manages → HADevice (MAC, hostname, version, availability)
+  └── manages → HABaseDeviceType* array (max 26 entities)
+                  ├── HALight
+                  ├── HASwitch
+                  ├── HAButton
+                  ├── HASensor
+                  ├── HANumber
+                  ├── HASelect
+                  └── HABinarySensor
+```
+
+**Utilities:** `HASerializer` (JSON config builder), `HANumeric` (fixed-precision numbers), `HADictionary` (string key-value store).
+
+## How Svitrix Uses It
+
+All integration lives in `src/MQTTManager/` (5 files):
+
+| File | Role |
+|------|------|
+| `MQTTManager.cpp` | Global `HADevice`, `HAMqtt`, entity pointer declarations |
+| `MQTTManager_Discovery.cpp` | Creates 25+ entities with `new HALight(...)` etc. |
+| `MQTTManager_Callbacks.cpp` | Inbound command handlers (HA → device) |
+| `MQTTManager_StateUpdates.cpp` | Outbound state publishing (device → HA) |
+| `MQTTManager_internal.h` | Shared `extern` declarations |
+
+**Global objects** (in MQTTManager.cpp):
+```cpp
+WiFiClient espClient;
+HADevice device;
+HAMqtt mqtt(espClient, device, 26); // max 26 entities
+```
+
+## Message Flow
+
+```
+HA UI → MQTT Broker → PubSubClient → HAMqtt → entity.onCommand(callback)
+                                                       ↓
+                                              MQTTManager_Callbacks.cpp
+
+Device state change → entity.setState() → HAMqtt.publish() → HA UI
+```
+
+## Key Patterns
+
+- **Compile-time exclusion** — `#define EX_ARDUINOHA_CAMERA` etc. in `ArduinoHADefines.h`
+- **PROGMEM strings** — `const __FlashStringHelper*` for flash storage
+- **Callbacks** — `entity->onStateCommand(fn)` for inbound commands
+- **Availability** — `HADevice::enableSharedAvailability()` + LWT on disconnect
+- **Lazy serialization** — `buildSerializer()` called only on MQTT connect
+
+## Important Constraints
+
+- **Max 26 entities** — hardcoded in `HAMqtt` constructor (3rd param)
+- **PubSubClient dependency** — `MQTT_MAX_PACKET_SIZE=8192` set in platformio.ini
+- **No modifications to library source** — only `ArduinoHADefines.h` exclusions customized
+- **Memory leak risk** — entity pointers allocated with `new` in Discovery, never `delete`-d (see issue #4)
+
+## Files You Should NOT Edit
+
+Everything under `src/` in this library is upstream code. To customize behavior:
+1. Toggle entity types via `EX_ARDUINOHA_*` defines in `ArduinoHADefines.h`
+2. Change integration logic in `src/MQTTManager/` (firmware side), not here

--- a/lib/interfaces/CLAUDE.md
+++ b/lib/interfaces/CLAUDE.md
@@ -1,0 +1,178 @@
+# Interfaces — AI Reference
+
+13 pure virtual interfaces that decouple all module-to-module communication. This is the architectural backbone of Svitrix.
+
+## Interface Map
+
+| Interface | Methods | Implementor(s) | Consumers |
+|-----------|---------|-----------------|-----------|
+| **IDisplayRenderer** | 11 | DisplayRenderer_ | UpdateManager, GameManager, SlotMachine, SvitrixSays, MenuManager, ServerManager |
+| **IDisplayControl** | 10 | DisplayManager_ | MenuManager, ServerManager, MQTTManager |
+| **IDisplayNavigation** | 12 | DisplayManager_ | MenuManager, ServerManager, MQTTManager, DataFetcher |
+| **IDisplayNotifier** | 9 | NotificationManager_ | ServerManager, MQTTManager |
+| **IMatrixHost** | 4 | DisplayManager_ | MatrixDisplayUi |
+| **IButtonHandler** | 4 | DisplayManager_, MenuManager_ | PeripheryManager |
+| **IButtonReporter** | 1 | MQTTManager_, ServerManager_ | PeripheryManager |
+| **INotifier** | 6 | MQTTManager_ | DisplayManager, NotificationManager |
+| **IPeripheryProvider** | 3 | PeripheryManager_ | DisplayManager, NotificationManager, MenuManager, ServerManager, MQTTManager |
+| **IPixelCanvas** | 6 | NeoMatrixCanvas | Effect system |
+| **ISound** | 3 | PeripheryManager_ | ServerManager, MQTTManager |
+| **IPower** | 2 | PowerManager_ | ServerManager, MQTTManager |
+| **IUpdater** | 2 | UpdateManager_ | ServerManager, MQTTManager, MenuManager |
+
+## Injection Pattern
+
+All modules use **setter injection with assert guards**:
+
+```cpp
+// In consumer header:
+class MenuManager_ {
+    IDisplayRenderer *renderer_ = nullptr;
+    IDisplayControl *control_ = nullptr;
+public:
+    void setDisplay(IDisplayRenderer *r, IDisplayControl *c, IDisplayNavigation *n);
+    bool hasDisplay() const { return renderer_ && control_ && nav_; }
+};
+
+// In main.cpp:
+MenuManager.setDisplay(&DisplayManager.getRenderer(), &DisplayManager, &DisplayManager);
+assert(MenuManager.hasDisplay());
+```
+
+## Interface Details
+
+### IDisplayRenderer (11 methods)
+```cpp
+void clear(), show();
+void resetTextColor(), setTextColor(uint32_t);
+void printText(x, y, text, centered, textCase);
+void HSVtext(x, y, text, clear, textCase);
+void drawFilledRect(x, y, w, h, color);
+void drawRGBBitmap(x, y, bitmap, w, h);
+void drawBMP(x, y, bitmap, w, h);
+void drawProgressBar(x, y, progress, pColor, pbColor);
+void drawMenuIndicator(cur, total, color);
+```
+
+### IDisplayControl (10 methods)
+```cpp
+void setBrightness(int), setPower(bool), powerStateParse(const char*);
+bool setAutoTransition(bool);
+void applyAllSettings(), setNewSettings(const char*);
+String getSettings(), getStats();
+bool moodlight(const char*);
+String ledsAsJson();
+```
+
+### IDisplayNavigation (12 methods)
+```cpp
+void nextApp(), previousApp();
+bool switchToApp(const char*);
+void updateAppVector(const char*), reorderApps(const String&);
+String getAppsAsJson(), getAppsWithIcon();
+bool parseCustomPage(const String&, const char*, bool);
+String getEffectNames(), getTransitionNames();
+void loadNativeApps(), setCustomAppColors(uint32_t);
+```
+
+### IDisplayNotifier (9 methods)
+```cpp
+bool generateNotification(uint8_t source, const char* json);
+void dismissNotify();
+bool indicatorParser(uint8_t indicator, const char* json);
+void setIndicator{1,2,3}Color(uint32_t);
+void setIndicator{1,2,3}State(bool);
+```
+
+### IMatrixHost (4 methods)
+```cpp
+CRGB* getLeds();
+void gammaCorrection();
+void sendAppLoop();
+bool setAutoTransition(bool);
+```
+
+### IButtonHandler (4 methods)
+```cpp
+void leftButton(), rightButton(), selectButton(), selectButtonLong();
+```
+
+### IButtonReporter (1 method)
+```cpp
+void sendButton(byte btn, bool state);  // btn: 0=left, 1=select, 2=right
+```
+
+### INotifier (6 methods)
+```cpp
+void publish(const char* topic, const char* payload);
+void rawPublish(const char* prefix, const char* topic, const char* payload);
+void setCurrentApp(String app);
+void setIndicatorState(uint8_t indicator, bool state, uint32_t color);
+bool subscribe(const char* topic);
+long getReceivedMessages() const;
+```
+
+### IPeripheryProvider (3 methods)
+```cpp
+void stopSound();
+void setVolume(uint8_t vol);
+unsigned long long readUptime();
+```
+
+### IPixelCanvas (6 methods)
+```cpp
+void drawPixel(x, y, CRGB/CHSV/uint16_t color);
+uint16_t Color(r, g, b);
+void drawRGBBitmap(x, y, bitmap, w, h);
+void fillRect(x, y, w, h, color);
+```
+
+### ISound (3 methods)
+```cpp
+const char* playRTTTLString(String rtttl);
+bool parseSound(const char* json);
+void r2d2(const char* msg);
+```
+
+### IPower (2 methods)
+```cpp
+void sleep(uint64_t seconds);
+void sleepParser(const char* json);
+```
+
+### IUpdater (2 methods)
+```cpp
+bool checkUpdate(bool withScreen);
+void updateFirmware();
+```
+
+## Known Violations (16 files bypass interfaces)
+
+These files use direct `#include` instead of interfaces (see issue #11):
+
+| File | Bypasses | Should Use |
+|------|----------|------------|
+| Overlays.cpp | DisplayManager, MenuManager, PeripheryManager, MQTTManager | Interfaces via injection |
+| Apps_internal.h | DisplayManager | IDisplayRenderer |
+| Apps_CustomApp.cpp | MQTTManager | INotifier |
+| Apps_Helpers.cpp | MQTTManager | INotifier |
+| AppContentRenderer.cpp | DisplayManager | IDisplayRenderer |
+| MenuManager.cpp | ServerManager | New interface or callback |
+| GameManager.cpp | ServerManager | New interface or callback |
+| Globals.cpp | DisplayManager | Remove dependency |
+
+## Missing Interfaces (Suggested)
+
+| Interface | Why Needed |
+|-----------|-----------|
+| IServerConnectivity | MenuManager/GameManager need `isConnected()` — currently bypass via direct include |
+| IGameManager | ServerManager needs game start/control — currently bypasses |
+
+## Rules for Adding New Interfaces
+
+1. Place in `lib/interfaces/src/`
+2. Pure virtual only — no implementation, no state
+3. Keep methods minimal — prefer small focused interfaces over large ones
+4. Every consumer must use setter injection + assert guards
+5. All wiring happens in `main.cpp` composition root
+6. Update this table when adding

--- a/lib/services/CLAUDE.md
+++ b/lib/services/CLAUDE.md
@@ -1,0 +1,92 @@
+# Services Library — AI Reference
+
+12 pure-logic utility libraries extracted from managers for testability. All stateless (except TextUtils), no hardware dependencies, 100% test coverage.
+
+## Service Map
+
+| Service | Purpose | Stateless | Key Methods |
+|---------|---------|-----------|-------------|
+| **ColorUtils** | Color space: hex↔uint32, Kelvin→RGB, HSV→RGB, lerp | Yes | `hexToUint32()`, `kelvinToRGB()`, `interpolateColor()`, `CRGBtoHex()` |
+| **GammaUtils** | LED gamma exponent (brightness-dependent log curve) | Yes | `calculateGamma(brightness)` |
+| **MathUtils** | Decimal rounding, two-segment log mapping | Yes | `roundToDecimalPlaces()`, `logMap()` |
+| **TextUtils** | Text width measurement (UTF-8 aware, bitmap font) | **No** — global `activeFont` | `setTextFont()`, `getTextWidth()` |
+| **UnicodeFont** | Glyph lookup, UTF-8 decode, bitmap rendering | Yes | `findGlyph()`, `utf8NextCodepoint()`, `renderGlyph()`, `getUnicodeTextWidth()` |
+| **TimeEffects** | Sine fade, square blink (millis passed as param) | Yes | `fadeColorAt()`, `textEffectAt()` |
+| **SensorCalc** | Battery %, brightness, LDR inversion, calibration | Yes | `calculateBatteryPercent()`, `calculateBrightness()`, `applySensorOffset()` |
+| **StatsBuilder** | Device telemetry → JSON string (no ArduinoJson) | Yes | `buildStatsJson(StatsData&)` |
+| **AppRegistry** | Native app names, app list serialization | Yes | `getNativeAppNames()`, `isNativeApp()`, `serializeAppList()` |
+| **MessageRouter** | MQTT topic → command enum routing | Yes | `routeTopic()`, `extractCustomTopicName()`, `isJsonPayload()` |
+| **HADiscovery** | HA entity descriptors and ID generation | Yes | `get*Descriptors()`, `buildEntityId()`, `getTotalEntityCount()` |
+| **OverlayMapping** | Weather overlay enum ↔ string | Yes | `overlayToString()`, `overlayFromString()` |
+| **PlaceholderUtils** | `{{key}}` template substitution via callback | Yes | `replacePlaceholdersWith(input, getValue)` |
+
+## Dependency Graph
+
+```
+MathUtils ← GammaUtils
+          ← SensorCalc
+
+UnicodeFont ← TextUtils
+
+ColorUtils (standalone, depends only on FastLED CRGB)
+TimeEffects (standalone, uses cmath sin)
+StatsBuilder (standalone, manual String building)
+AppRegistry (standalone)
+MessageRouter (standalone)
+HADiscovery (standalone)
+OverlayMapping (standalone)
+PlaceholderUtils (standalone)
+```
+
+No inter-service circular dependencies. Most services are fully standalone.
+
+## Who Uses What
+
+| Consumer | Services Used |
+|----------|--------------|
+| DisplayManager | ColorUtils, TimeEffects, GammaUtils, TextUtils, StatsBuilder, OverlayMapping |
+| DisplayRenderer | TextUtils, UnicodeFont, ColorUtils |
+| PeripheryManager | SensorCalc |
+| MQTTManager | MessageRouter, HADiscovery, AppRegistry, StatsBuilder, PlaceholderUtils |
+| Apps | ColorUtils, TimeEffects, TextUtils |
+| main.cpp | TextUtils (`setTextFont(SvitrixFont)` — must be called at startup) |
+
+## Test Coverage
+
+Every service has dedicated tests in `test/test_native/`:
+
+| Service | Test Suite(s) |
+|---------|--------------|
+| ColorUtils | `test_color/`, `test_crgb_hex/` |
+| GammaUtils | `test_gamma/` |
+| MathUtils | `test_math/`, `test_logmap/` |
+| TextUtils | `test_text_metrics/` |
+| UnicodeFont | `test_unicode_font/`, `test_glyph_render/`, `test_utf8/` |
+| TimeEffects | `test_time_effects/`, `test_effects/` |
+| SensorCalc | `test_sensor_calc/` |
+| StatsBuilder | `test_stats_builder/` |
+| AppRegistry | `test_app_registry/` |
+| MessageRouter | `test_message_router/` |
+| HADiscovery | `test_ha_discovery/` |
+| OverlayMapping | `test_overlay/` |
+| PlaceholderUtils | `test_placeholder_utils/` |
+
+Run all: `pio test -e native_test`
+
+## Design Patterns
+
+- **Pure functions** — deterministic, no side effects (TimeEffects takes `currentMillis` as param instead of calling `millis()`)
+- **Callback injection** — PlaceholderUtils and UnicodeFont use `std::function` / function pointers for flexibility
+- **Manual JSON** — StatsBuilder, AppRegistry build JSON strings manually (no ArduinoJson dependency — keeps native tests simple)
+- **Bit-packed structs** — UnicodeFont `UniGlyph` is 5 bytes (height/xAdvance/yOffset packed into single byte)
+- **Binary search** — `findGlyph()` uses binary search over sorted codepoint array
+- **Config structs** — Services consume types from `lib/config/src/ConfigTypes.h` (BatteryConfig, SensorConfig, MqttConfig, etc.)
+
+## Rules for Adding New Services
+
+1. Keep stateless — pass time/state as parameters, don't call `millis()` or read globals
+2. Add tests in `test/test_native/test_<name>/` — maintain 100% coverage
+3. Use Arduino `String` for compatibility but prefer `const char*` params where possible
+4. No ArduinoJson — build JSON manually for native test compatibility
+5. No hardware includes — services must compile in `native_test` environment
+6. Add the service to this table when created

--- a/lib/webserver/CLAUDE.md
+++ b/lib/webserver/CLAUDE.md
@@ -1,0 +1,112 @@
+# Web Server — AI Reference
+
+Async HTTP server wrapper around ESPAsyncWebServer. Provides WiFi management, captive portal, LittleFS file serving, OTA updates, and route registration used by `ServerManager`.
+
+## Files
+
+| File | Role |
+|------|------|
+| `esp-fs-webserver.h` | `FSWebServer` class declaration, `getBody()` helper, config option templates |
+| `esp-fs-webserver.cpp` | WiFi, captive portal, file ops, OTA, route registration |
+| `generated/setup_htm.h` | Gzipped PROGMEM — setup/config page (12 KB compressed) |
+| `generated/edit_htm.h` | Gzipped PROGMEM — LittleFS file manager with Ace editor |
+| `generated/htmls.h` | Raw PROGMEM strings — `screen_html`, `screenfull_html`, `backup_html`, `update_html`, `datafetcher_html`, plus custom icon picker |
+| `pages/*.html` | Source HTML files (7 pages) — edit these, then regenerate headers |
+
+## FSWebServer Class
+
+Wraps `AsyncWebServer` + `fs::FS` (LittleFS). Instance `mws` created in `ServerManager.cpp`.
+
+### Route Registration (used by ServerManager)
+
+```cpp
+void addHandler(const char *uri, WebRequestMethodComposite method, ArRequestHandlerFunction fn);
+void addHandler(const char *uri, ArRequestHandlerFunction handler);           // HTTP_ANY
+void addHandlerWithBody(const char *uri, WebRequestMethodComposite method, ArRequestHandlerFunction fn);
+void onNotFound(ArRequestHandlerFunction fn);
+```
+
+`addHandlerWithBody()` accumulates chunked POST body into `request->_tempObject`. Use `getBody(request)` to read as `String`.
+
+### WiFi Management
+
+```cpp
+IPAddress startWiFi(uint32_t timeout, const char *apSSID, const char *apPsw);  // STA → AP fallback
+IPAddress setAPmode(const char *ssid, const char *psk);                         // Force AP mode
+void setCaptiveWebage(const char *url);                                         // Captive portal target
+```
+
+### Authentication
+
+```cpp
+void setAuth(const String &user, const String &pass);  // HTTP Basic Auth on all routes
+```
+
+### Setup Page Options (`INCLUDE_SETUP_HTM`)
+
+Dynamic config form backed by `/DoNotTouch.json` on LittleFS:
+
+```cpp
+void addOptionBox(const char *boxTitle);
+void addOption(const char *label, T val, bool hidden = false, ...);
+void addDropdownList(const char *label, const char **array, size_t size);
+bool getOptionValue(const char *label, T &var);
+bool saveOptionValue(const char *label, T val);
+```
+
+### File Manager (`INCLUDE_EDIT_HTM`)
+
+| Method | Path | Action |
+|--------|------|--------|
+| GET | `/edit` | File manager page |
+| GET | `/list?dir=/` | List directory (JSON) |
+| GET | `/status` | FS usage stats (JSON) |
+| PUT | `/edit` | Create file/directory |
+| POST | `/edit` | Upload file (multipart) |
+| DELETE | `/edit` | Delete file/directory |
+
+### OTA Update
+
+Built-in at `/update` (GET = upload form, POST = firmware upload via `Update` API). Reboots on success.
+
+## Built-in Routes (registered in `begin()`)
+
+| Path | Description |
+|------|-------------|
+| `/` | Index: serves `/index.htm`, falls back to `/setup` |
+| `/setup` | Device configuration page (gzipped PROGMEM) |
+| `/scan` | WiFi network scan (JSON) |
+| `/connect` | WiFi connection (POST) |
+| `/ipaddress` | Current IP address |
+| `/restart` | Reboot device |
+| `/update` | OTA firmware upload |
+| `/redirect`, `/connecttest.txt`, `/hotspot-detect.html`, `/generate_204` | Captive portal redirects |
+
+## HTML Page Pipeline
+
+```
+pages/*.html  →  python3 tools/web_compress.py  →  generated/*.h  →  PROGMEM in firmware
+```
+
+- `setup.html`, `edit.html` — gzip-compressed byte arrays, `Content-Encoding: gzip`
+- All others — raw C++ string literals (`R"EOF(...)EOF"`) as `PROGMEM`
+
+## CORS
+
+Global headers on all responses:
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: PUT,POST,GET,OPTIONS,DELETE
+Access-Control-Allow-Headers: *
+```
+
+## Dependencies
+
+| Dependency | Usage |
+|------------|-------|
+| ESPAsyncWebServer | Underlying async HTTP server |
+| LittleFS | File storage and serving |
+| DNSServer | Captive portal DNS in AP mode |
+| WiFi / esp_wifi | STA/AP connection management |
+| Update | OTA firmware flashing |
+| ArduinoJson v6 | `/DoNotTouch.json` config persistence |

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,410 @@
+# src/ Standalone Modules — AI Reference
+
+Documentation for modules that live as standalone `.cpp/.h` files in `src/` (no subdirectory).
+
+---
+
+## ServerManager
+
+HTTP REST API server, WiFi connectivity, mDNS discovery, UDP device discovery, and TCP game controller input. Primary external control interface alongside MQTT.
+
+### Files
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `ServerManager.h` | 39 | Public API, singleton, IButtonReporter |
+| `ServerManager.cpp` | 536 | WiFi setup, HTTP endpoints, UDP/TCP, settings loader |
+
+### Interfaces
+
+**Implements:** `IButtonReporter` — forwards button presses to external HTTP callback.
+
+**Consumes (7):**
+
+| Interface | Used for |
+|-----------|----------|
+| `IDisplayRenderer` | `HSVtext()` during erase/reset |
+| `IDisplayControl` | Power, moodlight, settings, stats, LED export |
+| `IDisplayNavigation` | App list, switching, reordering, custom apps, effects, transitions |
+| `IDisplayNotifier` | Notifications, indicators, dismiss |
+| `ISound` | RTTTL playback, sound files, R2D2 |
+| `IPower` | Sleep/wake |
+| `IUpdater` | OTA firmware update |
+
+### HTTP Endpoints (33)
+
+#### Device Control
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/power` | Set display power state |
+| `POST` | `/api/sleep` | Deep sleep (JSON: seconds) |
+| `ANY` | `/api/reboot` | Restart ESP32 |
+| `ANY` | `/api/erase` | Factory reset: wipe WiFi + LittleFS + settings |
+| `ANY` | `/api/resetSettings` | Reset settings to defaults |
+| `POST` | `/api/doupdate` | Check + apply OTA firmware update |
+
+#### Display & Apps
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/loop` | Get current app loop as JSON |
+| `GET` | `/api/apps` | Get apps with icon data |
+| `POST` | `/api/apps` | Update app vector |
+| `POST` | `/api/switch` | Switch to app by name |
+| `ANY` | `/api/nextapp` | Navigate to next app |
+| `POST` | `/api/previousapp` | Navigate to previous app |
+| `POST` | `/api/reorder` | Reorder app vector |
+| `POST` | `/api/custom?name=X` | Create/update/delete custom app |
+| `POST` | `/api/moodlight` | Set moodlight mode |
+
+#### Notifications & Indicators
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/notify` | Push notification |
+| `ANY` | `/api/notify/dismiss` | Dismiss current notification |
+| `POST` | `/api/indicator1` | Set indicator 1 |
+| `POST` | `/api/indicator2` | Set indicator 2 |
+| `POST` | `/api/indicator3` | Set indicator 3 |
+
+#### Audio
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/rtttl` | Play RTTTL melody |
+| `POST` | `/api/sound` | Play sound file |
+| `POST` | `/api/r2d2` | Play R2D2-style sounds |
+
+#### Settings & Stats
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/settings` | Get all settings as JSON |
+| `POST` | `/api/settings` | Update settings (partial JSON) |
+| `GET` | `/api/stats` | Device stats |
+| `GET` | `/api/screen` | LED buffer as JSON (256 pixels) |
+| `GET` | `/api/effects` | List available visual effects |
+| `GET` | `/api/transitions` | List available transition effects |
+
+#### DataFetcher
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/datafetcher` | List configured data sources |
+| `POST` | `/api/datafetcher` | Add new data source |
+| `DELETE` | `/api/datafetcher?name=X` | Remove data source |
+| `POST` | `/api/datafetcher/fetch?name=X` | Force-fetch a data source |
+
+#### Web Pages
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/version` | Firmware version string |
+| `GET` | `/screen` | Screen mirror HTML page |
+| `GET` | `/fullscreen?fps=N` | Fullscreen screen mirror |
+| `GET` | `/backup` | Backup/restore HTML page |
+| `GET` | `/datafetcher` | DataFetcher config HTML page |
+
+### Communication Protocols
+
+**UDP Discovery (port 4210):** listens for `"FIND_SVITRIX"`, responds on 4211 with hostname.
+
+**TCP Server (port 8080):** single-client, newline-delimited messages → `GameManager.ControllerInput()`.
+
+**HTTP Button Callback:** POST to `systemConfig.buttonCallback` URL on button press/release.
+
+### Important Patterns
+
+- Route ordering matters — `/api/datafetcher/fetch` before `/api/datafetcher`
+- AP mode fallback at `192.168.4.1` — only `/version` endpoint registered
+- FSWebServer auto-generates `/setup` page from `addOption()`/`addOptionBox()` calls
+- Auth via `mws.setAuth(user, pass)`
+- mDNS registers `http` and `svitrix` TCP services
+
+---
+
+## PeripheryManager
+
+Hardware abstraction singleton. Manages physical buttons, I2C temperature/humidity sensors, LDR (light), battery ADC, and piezo buzzer.
+
+### Files
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `PeripheryManager.h` | 77 | Public API, singleton, IPeripheryProvider + ISound |
+| `PeripheryManager.cpp` | 541 | Hardware init, sensor loops, button dispatch, sound |
+
+### Interfaces
+
+**Implements:** `IPeripheryProvider`, `ISound`
+
+**Dispatches to (multi-consumer vectors):**
+- `IButtonHandler` — `leftButton()`, `rightButton()`, `selectButton()`, `selectButtonLong()`
+- `IButtonReporter` — `sendButton(btn, state)`
+
+### Hardware Components
+
+#### Buttons (4x EasyButton)
+
+| Button | GPIO | Events |
+|--------|------|--------|
+| Left | 26 | `onPressed` → `dispatchLeftButton()` |
+| Right | 14 | `onPressed` → `dispatchRightButton()` |
+| Select | 27 | `onPressed`, `onPressedFor(1000ms)`, `onSequence(2, 300ms)` |
+| Reset | 13 | `onPressedFor(5000ms)` → factory reset (ULANZI only) |
+
+Button swap: left/right swapped when `rotateScreen XOR swapButtons`.
+
+#### I2C Sensors (auto-detected, first match wins)
+
+1. **BME280** (0x76/0x77) — temp + humidity
+2. **BMP280** (0x76/0x77) — temp only
+3. **HTU21DF** — temp + humidity
+4. **SHT31** (0x44) — temp + humidity
+
+Readings every **10 seconds**, filtered with calibration offsets.
+
+#### LDR — GPIO 35, read every **100ms**, median+mean filtered
+
+#### Battery (ULANZI only) — GPIO 34 ADC, read every **10 seconds**
+
+#### Buzzer — GPIO 15, PWM via `MelodyPlayer`, async RTTTL playback
+
+### Button Dispatch Architecture
+
+```
+EasyButton callbacks
+  └→ check blockNavigation
+      └→ dispatch*()
+          ├→ IButtonHandler vector: DisplayManager_, MenuManager_
+          └→ IButtonReporter vector: MQTTManager_, ServerManager_
+```
+
+### Callback Registration
+
+| Method | Purpose |
+|--------|---------|
+| `addButtonHandler(IButtonHandler*)` | Left/right/select dispatch |
+| `addButtonReporter(IButtonReporter*)` | Raw button state reporting |
+| `setOnPowerToggle(fn)` | Double-press power toggle |
+| `setOnBrightnessChange(fn)` | Auto-brightness updates |
+| `setOnFactoryReset(fn)` | Reset button long press |
+| `setIsMenuActive(fn)` | Suppress reports during menu |
+
+### Tick Loop
+
+```
+tick()
+  ├─ Read buttons (dispatch reports if menu not active)
+  ├─ Every 10s: read battery + temperature/humidity
+  └─ Every 100ms: read LDR, compute auto-brightness
+```
+
+---
+
+## MenuManager
+
+On-device settings menu rendered on the LED matrix. Adjusts display, time, audio, and app settings via physical buttons.
+
+### Files
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `MenuManager.h` | 47 | Singleton, `IButtonHandler` implementation |
+| `MenuManager.cpp` | 491 | Menu state machine, 13 menu items, button handlers |
+
+### Menu Structure (13 items)
+
+| Menu | Controls |
+|------|----------|
+| BRIGHT | `brightnessPercent` (1-100%) or AUTO |
+| COLOR | `textColor` (15 preset colors) |
+| SWITCH | `autoTransition` (ON/OFF) |
+| T-SPEED | `timePerTransition` (200-2000ms) |
+| APPTIME | `timePerApp` (1-30s) |
+| TIME | `timeFormat` (8 strftime patterns) |
+| DATE | `dateFormat` (9 strftime patterns) |
+| WEEKDAY | `startOnMonday` (MON/SUN) |
+| TEMP | `isCelsius` (°C/°F) |
+| APPS | Toggle 5 native apps |
+| SOUND | `soundActive` (ON/OFF) |
+| VOLUME | `soundVolume` (0-30) |
+| UPDATE | Triggers OTA update |
+
+### Navigation
+
+| Button | MainMenu | Submenu |
+|--------|----------|---------|
+| Right | Next item | Increase value |
+| Left | Previous item | Decrease value |
+| Select (short) | Enter submenu | Toggle |
+| Select (long) | Exit menu | Save + back |
+
+### Interfaces
+
+**Provides:** `IButtonHandler` → PeripheryManager
+
+**Consumes:** `IDisplayRenderer`, `IDisplayControl`, `IDisplayNavigation`, `IPeripheryProvider`, `IUpdater`
+
+---
+
+## UpdateManager
+
+OTA firmware update manager. Checks remote server for new versions and performs HTTPS firmware updates with progress display.
+
+### Files
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `UpdateManager.h` | 23 | Singleton, `IUpdater` implementation |
+| `UpdateManager.cpp` | 36 | Version check, firmware download, progress callbacks |
+
+### OTA Flow
+
+1. `checkUpdate(withScreen)` — HTTPS GET version string, compare against `VERSION` constant
+2. `updateFirmware()` — download via `httpUpdate.update()` with pinned CA cert (`cert.h`)
+3. Progress bar rendered via `IDisplayRenderer::drawProgressBar()` (green fill, y=7)
+4. On success: automatic reboot
+
+### Interfaces
+
+**Provides:** `IUpdater` → ServerManager, MQTTManager, MenuManager
+
+**Consumes:** `IDisplayRenderer`
+
+### Config Fields
+
+| Field | Purpose |
+|-------|---------|
+| `systemConfig.updateVersionUrl` | URL returning plain-text version |
+| `systemConfig.updateFirmwareUrl` | URL to firmware `.bin` file |
+| `systemConfig.updateAvailable` | Flag set by `checkUpdate()` |
+
+---
+
+## PowerManager
+
+Deep sleep controller. Puts the ESP32 into `esp_deep_sleep` with timer and GPIO wake sources.
+
+### Files
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `PowerManager.h` | 23 | Singleton, `IPower` implementation |
+| `PowerManager.cpp` | 36 | Sleep logic, JSON parser, wake source config |
+
+### Wake Sources
+
+| Source | Config |
+|--------|--------|
+| **Timer** | `esp_sleep_enable_timer_wakeup(seconds * 1e6)` |
+| **GPIO 27** | `esp_sleep_enable_ext0_wakeup(GPIO_NUM_27, LOW)` — middle button |
+
+### Interfaces
+
+**Provides:** `IPower` → ServerManager, MQTTManager
+
+**Consumes:** none — uses ESP-IDF sleep APIs directly.
+
+---
+
+## Globals & Config
+
+Central configuration store and persistent settings. Defines all config structs as global externs, handles load/save to NVS (Preferences) and LittleFS.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `Globals.h` | Extern declarations for 13 config structs, debug macros |
+| `Globals.cpp` | Config struct definitions with defaults, NVS load/save, LittleFS init |
+| `lib/config/src/ConfigTypes.h` | All 13 config struct definitions + `TempSensorType` enum |
+
+### 13 Config Structs
+
+| Struct | Key Fields | Purpose |
+|--------|------------|---------|
+| `MqttConfig` | host, port, user, pass, prefix | MQTT broker |
+| `NetworkConfig` | isStatic, ip, gateway, subnet, dns | Static IP |
+| `HaConfig` | discovery, prefix | Home Assistant discovery |
+| `AuthConfig` | user, pass | HTTP auth |
+| `SensorConfig` | currentTemp, currentHum, currentLux, tempSensorType, offsets | Sensor readings |
+| `BatteryConfig` | percent, raw, minRaw, maxRaw | Battery (ULANZI) |
+| `DisplayConfig` | matrixLayout, matrixFps, matrixOff, mirror, rotate, backgroundEffect | Matrix settings |
+| `BrightnessConfig` | brightness, autoBrightness, min/max, ldrGamma/Factor | Brightness |
+| `ColorConfig` | textColor, timeColor, dateColor, batColor, tempColor, humColor, weekday, calendar | Colors |
+| `TimeConfig` | timeFormat, dateFormat, timeMode, startOnMonday, ntpServer, isCelsius | Time/date |
+| `AppConfig` | showTime/Date/Bat/Temp/Hum, autoTransition, transEffect, scrollSpeed | Apps |
+| `AudioConfig` | soundActive, soundVolume, bootSound | Audio |
+| `SystemConfig` | debugMode, hostname, deviceId, updateUrls, buttonCallback | System |
+
+### Persistence — Three Layers (later overrides earlier)
+
+1. **Compile-time defaults** — initializer lists in `Globals.cpp`
+2. **NVS (Preferences)** — `loadSettings()` / `saveSettings()` (30+ keys, namespace `"svitrix"`)
+3. **`/dev.json` (LittleFS)** — `loadDevSettings()` for advanced overrides (26 optional keys)
+
+### Key Functions
+
+| Function | Purpose |
+|----------|---------|
+| `loadSettings()` | Init LittleFS → load NVS → set deviceId → load dev.json |
+| `saveSettings()` | Write user settings to NVS |
+| `formatSettings()` | Wipe NVS namespace (factory reset) |
+| `startLittleFS()` | Mount LittleFS, create dirs, handle corrupt FS |
+| `loadDevSettings()` | Parse `/dev.json` for advanced overrides |
+| `getID()` | Generate device ID from MAC: `svitrix_XXYYZZ` |
+
+### Debug Macros
+
+`DEBUG_PRINTLN(x)` and `DEBUG_PRINTF(fmt, ...)` — print with timestamp and function name. Always enabled. Expensive calls gated by `systemConfig.debugMode`.
+
+---
+
+## AppContent & AppContentRenderer
+
+Shared rendering data structure and pipeline used by both custom apps and notifications on the 32x8 LED matrix.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `AppContent.h` | `AppContentBase` struct + free function declarations |
+| `AppContentRenderer.cpp` | Shared rendering functions (icon, text, scroll, overlay) |
+
+### AppContentBase — Key Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `text` | String | Display text |
+| `color` | uint32_t | Text color |
+| `icon` | File | Icon file handle (8x8 JPEG/GIF) |
+| `rainbow` | bool | Per-character HSV rainbow |
+| `gradient[2]` | int | Two-color gradient |
+| `fragments` / `colors` | vector | Per-segment colored text |
+| `scrollposition` / `scrollSpeed` | float | Scroll animation state |
+| `pushIcon` | byte | Icon push animation mode |
+| `progress` / `pColor` / `pbColor` | int/uint32_t | Progress bar |
+| `barData[16]` / `lineData[16]` | int | Bar/line chart data |
+| `effect` | int | Background effect index |
+| `overlay` | OverlayEffect | Weather overlay |
+| `drawInstructions` | String | JSON draw commands |
+
+### Inheritance
+
+```
+AppContentBase
+├── CustomApp    adds: name, lifetime, duration, repeat, bounce, currentFrame, iconName
+└── Notification adds: duration, repeat, hold, wakeup, sound, rtttl, startime
+```
+
+### Rendering Pipeline (4 free functions)
+
+1. **`renderAppIcon()`** — icon, push animation, separator, draw instructions, progress bar, charts
+2. **`updateScrollAnimation()`** — advance scroll position, handle delays and speed
+3. **`renderAppText()`** — centered/scrolling text, fragments or solid (rainbow/gradient)
+4. **`renderAppOverlay()`** — weather overlay via `EffectOverlay()`
+
+### Rendering Order
+
+```
+1. renderAppIcon()          ← if topText
+2. updateScrollAnimation()  ← advance scroll
+3. renderAppText()          ← draw text
+4. renderAppIcon()          ← if !topText
+5. renderAppOverlay()       ← weather effects
+```

--- a/src/DataFetcher/CLAUDE.md
+++ b/src/DataFetcher/CLAUDE.md
@@ -1,0 +1,149 @@
+# DataFetcher — AI Reference
+
+Singleton module that periodically fetches values from external HTTP/HTTPS APIs and pushes them as custom apps to the display via `IDisplayNavigation::parseCustomPage()`.
+
+## File Map
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `DataFetcher.h` | 45 | Public API, singleton definition |
+| `DataFetcher.cpp` | 403 | HTTP fetching, JSON extraction, source CRUD, LittleFS persistence |
+| `DataFetcherConfig.h` | 18 | `DataSourceConfig` struct — per-source configuration |
+
+## Interfaces
+
+**Implements:** None (no interface of its own).
+
+**Injected Dependencies (1):**
+```cpp
+void setNavigation(IDisplayNavigation *n);
+```
+
+Uses `IDisplayNavigation::parseCustomPage(name, json, show)` to feed fetched data into the custom app pipeline — the same path used by MQTT `/custom/#` and the HTTP API.
+
+## DataSourceConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | String | Unique ID, becomes the custom app name (e.g., `"btc"`) |
+| `url` | String | Full HTTP/HTTPS URL |
+| `jsonPath` | String | Dot-notation path to extract (e.g., `"bitcoin.usd"`, `"data.0.price"`) |
+| `displayFormat` | String | printf-style format (e.g., `"$%.0f"`) or empty for raw |
+| `icon` | String | Icon name from LittleFS, or empty |
+| `textColor` | String | Hex color `"#RRGGBB"` or empty for default |
+| `interval` | uint32_t | Polling interval in seconds |
+
+**Constraints:**
+- `MIN_INTERVAL` = 60 seconds
+- `DEFAULT_INTERVAL` = 900 seconds (15 min)
+- `MAX_SOURCES` = 8
+
+## Data Flow
+
+```
+External API
+    │  HTTP GET (every N seconds)
+    ▼
+DataFetcher_::fetchAndPush()
+    │  1. HTTP GET → response body (max 4 KB)
+    │  2. extractJsonValue(body, jsonPath) → raw value string
+    │  3. formatValue(src, raw) → printf-formatted string
+    │  4. buildCustomAppJson(src, formatted) → {"text","icon","color","lifetime":0}
+    ▼
+IDisplayNavigation::parseCustomPage(name, json, true)
+    │  (same pipeline as MQTT custom apps)
+    ▼
+Display shows as custom app
+```
+
+## Tick Behavior
+
+- **Round-robin**: checks one source per `tick()` call to avoid blocking the main loop
+- **Heap guard**: skips fetch if free heap < 40 KB (`MIN_FREE_HEAP`)
+- **Staggered start**: all `lastFetch_` initialized to 0, so sources fetch on first eligible tick
+- Only runs when `nav_` is set and `sources_` is non-empty
+
+## Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `setup()` | Creates `/DATAFETCHER/` dir, loads sources from LittleFS |
+| `tick()` | Round-robin poll — checks one source per call |
+| `addSource(json)` | Parse JSON config, upsert by name, save to LittleFS |
+| `removeSource(name)` | Remove source + clear its custom app from display |
+| `forceFetch(name)` | Immediately fetch a specific source (used by API) |
+| `getSourcesAsJson()` | Serialize all sources as JSON array |
+| `loadSources()` / `saveSources()` | LittleFS persistence to `/DATAFETCHER/sources.json` |
+
+### Private Methods
+
+| Method | Description |
+|--------|-------------|
+| `fetchAndPush(index)` | HTTP GET + extract + format + push to display |
+| `extractJsonValue(json, path)` | Walk dot-notation path through ArduinoJson (supports objects + arrays) |
+| `formatValue(src, raw)` | Apply printf-style `displayFormat` to raw value |
+| `buildCustomAppJson(src, value)` | Build JSON for `parseCustomPage()` with text, icon, color, lifetime=0 |
+
+## HTTP API Endpoints (registered in ServerManager)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/datafetcher` | List all sources as JSON array |
+| `POST` | `/api/datafetcher` | Add/update source (body: DataSourceConfig JSON) |
+| `DELETE` | `/api/datafetcher?name=X` | Remove source by name |
+| `POST` | `/api/datafetcher/fetch?name=X` | Force immediate fetch for a source |
+| `GET` | `/datafetcher` | Web UI page (`datafetcher_html`) |
+
+### Add/Update Source JSON
+
+```json
+{
+  "name": "btc",
+  "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+  "jsonPath": "bitcoin.usd",
+  "displayFormat": "$%.0f",
+  "icon": "btc",
+  "color": "#F7931A",
+  "interval": 300
+}
+```
+
+Required fields: `name`, `url`, `jsonPath`. All others optional.
+
+## HTTPS Handling
+
+- HTTPS requests use `WiFiClientSecure` with `setInsecure()` (no cert validation)
+- Rationale: DataFetcher hits arbitrary third-party APIs whose CAs cannot be pinned in advance
+- HTTP requests use plain `WiFiClient`
+
+## Persistence
+
+- Sources stored in LittleFS at `/DATAFETCHER/sources.json`
+- Directory created in `setup()` if missing
+- `saveSources()` called on every add/remove operation
+- Sources loaded automatically on `setup()`
+
+## Wiring in main.cpp
+
+```cpp
+DataFetcher.setNavigation(&DisplayManager);     // IDisplayNavigation
+assert(DataFetcher.hasNavigation());
+
+// In setup(), after WiFi:
+DataFetcher.setup();
+
+// In loop(), only when connected:
+if (ServerManager.isConnected) {
+    DataFetcher.tick();
+}
+```
+
+## Important Constraints
+
+- Max response body: 4 KB (`MAX_RESPONSE_SIZE`) — larger responses rejected
+- JSON parsing buffer: 2 KB `DynamicJsonDocument` for response extraction
+- Connect timeout: 5 s, read timeout: 10 s
+- One HTTP request per tick (round-robin) to avoid blocking
+- Custom apps created with `lifetime: 0` — DataFetcher manages their lifecycle, they never auto-expire
+- On `removeSource()`, the custom app is cleared from display via `parseCustomPage(name, "{}", false)`
+- No authentication support — only public APIs (no API key headers)

--- a/src/DisplayManager/CLAUDE.md
+++ b/src/DisplayManager/CLAUDE.md
@@ -1,0 +1,162 @@
+# DisplayManager — AI Reference
+
+Coordinator for all visual output on the 32x8 WS2812B LED matrix. Split into 3 classes (Phase 11 refactoring).
+
+## Architecture
+
+```
+DisplayManager_ (singleton, coordinator)
+  ├── implements: IButtonHandler, IMatrixHost, IDisplayControl, IDisplayNavigation
+  ├── owns: DisplayRenderer_ (drawing engine)
+  └── owns: NotificationManager_ (notification queue + indicators)
+```
+
+## File Map
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `DisplayManager.h` | 307 | Public API: 4 interfaces + 79 delegation wrappers |
+| `DisplayManager.cpp` | 450 | Lifecycle, tick loop, power, brightness, buttons, matrix layout |
+| `DisplayRenderer.h/cpp` | 768 | Text (SvitrixFont), primitives, charts, JPEG/GIF, draw commands |
+| `NotificationManager.h/cpp` | 280 | Notification parsing/display, 3 RGB indicators, dismissal |
+| `DisplayManager_internal.h` | — | Shared globals (LED buffer, matrix, UI framework) |
+| `DisplayManager_CustomApps.cpp` | 745 | Custom app lifecycle: parse, persist, load, lifetime |
+| `DisplayManager_ParseHelpers.cpp` | 295 | Shared JSON parsers for custom apps and notifications |
+| `DisplayManager_Settings.cpp` | 270 | Settings get/set, device stats, LED export |
+| `DisplayManager_Artnet.cpp` | 138 | Art-Net DMX receiver, moodlight mode |
+
+## Shared Globals (DisplayManager_internal.h)
+
+```cpp
+extern CRGB leds[256];              // Primary LED buffer
+extern CRGB ledsCopy[256];          // Pre-gamma copy for color readback
+extern FastLED_NeoMatrix *matrix;   // NeoMatrix driver
+extern MatrixDisplayUi *ui;         // App framework
+extern int16_t cursor_x, cursor_y;  // Text cursor
+extern uint32_t textColor;          // Current draw color
+extern float actualBri;             // Current brightness
+extern bool artnetMode, moodlightMode;
+```
+
+## DisplayManager_ — Key API
+
+### Lifecycle
+- `setup()` — Init FastLED, NeoMatrix, UI framework, load settings
+- `tick()` — Main loop: dispatch to game/artnet/moodlight/UI
+- `gammaCorrection()` — Apply gamma + optional mirror to LED buffer
+
+### tick() Dispatch Order
+1. GameManager active → `GameManager.tick()`
+2. AP mode → Show "AP MODE" text
+3. artnetMode → handled by DMX callback
+4. moodlightMode → handled by moodlight()
+5. Normal → `ui->update()` (app framework)
+6. Always: poll artnet, checkNewYear()
+
+### Power & Brightness
+- `setBrightness(int)` — respects matrixOff + wakeup notifications
+- `setPower(bool)` — toggle display with sleep animation
+- `showSleepAnimation()` — bouncing "Z" (700ms)
+
+### Custom Apps
+- `parseCustomPage(name, json, preventSave)` — create/update/delete custom app
+- `loadCustomApps()` — load from `/CUSTOMAPPS/*.json` at boot
+- `loadNativeApps()` — register Time/Date/Temp/Hum/Bat based on config
+- `updateAppVector(json)` — add/remove/reorder apps
+- `reorderApps(json)` — reorder app vector
+- `switchToApp(json)` — switch to app by name
+
+### Settings (DisplayManager_Settings.cpp)
+- `getSettings()` → JSON with 50+ config fields
+- `setNewSettings(json)` — partial update, applies + persists
+- `getStats()` → device status JSON (battery, sensors, uptime, WiFi, RAM)
+- `ledsAsJson()` → LED buffer export
+
+### Art-Net (DisplayManager_Artnet.cpp)
+- 768 channels (256 LEDs × 3), universes 0-1 + universe 10 (global brightness)
+- `moodlight(json)` — `{"color":"#RRGGBB"}` or `{"kelvin":N}`, empty string disables
+
+## DisplayRenderer_ — Drawing API
+
+Implements `IDisplayRenderer`. All methods are stateless, draw to shared globals.
+
+### Text Rendering
+- `printText(x, y, text, centered, textCase)` — single color, SvitrixFont
+- `HSVtext(x, y, text, clear, textCase)` — per-character rainbow (hue cycles)
+- `GradientText(x, y, text, c1, c2, clear, textCase)` — linear color interpolation
+- `renderColoredText(...)` — dispatcher: rainbow → HSV, gradient → Gradient, else solid+effects
+- `matrixPrint(codepoint)` — core glyph renderer via `renderGlyph()`
+
+### Primitives
+- `drawPixel`, `drawLine` (Bresenham), `drawRect`, `drawFilledRect`
+- `drawCircle`, `fillCircle`, `drawFastVLine`
+
+### Images
+- `drawBMP(x, y, bitmap, w, h)` — 565 RGB
+- `drawRGBBitmap(x, y, bitmap, w, h)` — 888 RGB
+- `drawJPG(x, y, file)` / `drawJPG(x, y, data, size)` — JPEG decode
+
+### Charts
+- `drawBarChart(x, y, data, size, withIcon, color, barBG)` — vertical bars
+- `drawLineChart(x, y, data, size, withIcon, color)` — connected line segments
+
+### JSON Draw Instructions
+`processDrawInstructions(xOffset, yOffset, json)` — parses array of commands:
+```json
+[["dp",[x,y,color]], ["dl",[x0,y0,x1,y1,color]], ["dr",[x,y,w,h,color]],
+ ["df",[x,y,w,h,color]], ["dc",[x,y,r,color]], ["dfc",[x,y,r,color]],
+ ["dt",[x,y,"text",color]], ["db",[x,y,w,h,[rgb...]]]]
+```
+
+## NotificationManager_ — Notification Queue
+
+Implements `IDisplayNotifier`. Stores notifications in `deque<Notification>`.
+
+### generateNotification(source, json)
+- `source` — 0=MQTT, 1=HTTP
+- Parses: text, icon (file or base64), duration, sound/rtttl, hold, wakeup, stack, clients
+- Shared fields with custom apps: progress bar, charts, gradients, effects, overlays, draw instructions
+- Client forwarding: `"clients": ["mqtt://device1", "http://192.168.1.1"]`
+
+### dismissNotify()
+- Shifts to next notification or clears queue
+- Stops sound, restores brightness if wakeup was active
+
+### Indicators (1-3)
+- `indicatorParser(indicator, json)` — `{"color":"#RRGGBB","blink":ms,"fade":ms}`
+- `setIndicator{1,2,3}Color(uint32_t)` / `setIndicator{1,2,3}State(bool)`
+- Publishes state changes via `INotifier`
+
+## Shared JSON Parsers (ParseHelpers)
+
+Used by both custom apps and notifications:
+- `parseProgressBar()` — progress (0-100), colors
+- `parseChartData()` — bar/line arrays (max 16 points, auto-scaled to 0-8)
+- `parseGradient()` — [color1, color2]
+- `parseTextOrFragments()` — plain text or `[{t:"...",c:"..."}]` colored fragments
+- `parseCommonAppFields()` — 15 display/effect fields
+- `readColorField()` — hex `"#RRGGBB"` or `[r,g,b]`
+
+## Dependency Injection
+
+```cpp
+void setNotifier(INotifier *n);           // MQTT publisher
+void setPeriphery(IPeripheryProvider *p);  // Audio, uptime
+void setMenuActiveQuery(bool (*cb)());    // Menu state callback
+```
+
+## Wiring in main.cpp
+
+```cpp
+PeripheryManager.addButtonHandler(&DisplayManager);      // IButtonHandler
+DisplayManager.setNotifier(&MQTTManager);                 // INotifier
+DisplayManager.setPeriphery(&PeripheryManager);           // IPeripheryProvider
+// Other modules receive interfaces:
+MenuManager.setDisplay(&DisplayManager.getRenderer(), &DisplayManager, &DisplayManager);
+ServerManager.setDisplay(&DisplayManager.getRenderer(), &DisplayManager, &DisplayManager, &DisplayManager.getNotifier());
+MQTTManager.setDisplay(&DisplayManager, &DisplayManager, &DisplayManager.getNotifier());
+```
+
+## Backward Compatibility
+
+DisplayManager_ delegates ~79 methods to renderer_ and notifMgr_. Apps calling `DisplayManager.drawPixel()` still work — forwarded internally.

--- a/src/MQTTManager/CLAUDE.md
+++ b/src/MQTTManager/CLAUDE.md
@@ -1,0 +1,143 @@
+# MQTTManager — AI Reference
+
+Central MQTT communication and Home Assistant integration singleton. Manages broker connection, message dispatch, HA auto-discovery (25 entities), and state synchronization.
+
+## File Map
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `MQTTManager.h` | 135 | Public API, singleton, INotifier + IButtonReporter |
+| `MQTTManager.cpp` | 289 | Instance, connection lifecycle, tick, publish methods |
+| `MQTTManager_internal.h` | 127 | Shared extern declarations for 25 HA entity pointers + ID buffers |
+| `MQTTManager_Messages.cpp` | 188 | Incoming message reception + command dispatch |
+| `MQTTManager_Callbacks.cpp` | 179 | 7 ArduinoHA callback handlers (HA → device) |
+| `MQTTManager_Discovery.cpp` | 245 | HA entity creation + metadata |
+| `MQTTManager_StateUpdates.cpp` | 165 | Stats publishing, button/indicator sync (device → HA) |
+
+## Interfaces
+
+**Implements:**
+- `INotifier` — publish/subscribe, setCurrentApp, setIndicatorState
+- `IButtonReporter` — sendButton(btn, state)
+
+**Injected Dependencies (7):**
+```cpp
+void setDisplay(IDisplayControl*, IDisplayNavigation*, IDisplayNotifier*);
+void setServices(ISound*, IPower*, IUpdater*, IPeripheryProvider*);
+```
+
+## HA Entities (25 total)
+
+| Type | Count | Entities |
+|------|-------|----------|
+| **HALight** | 4 | Matrix (brightness+RGB), Indicator 1/2/3 (RGB) |
+| **HASelect** | 2 | BriMode (Manual/Auto), transEffect (11 transitions) |
+| **HAButton** | 4 | dismiss, nextApp, prevApp, doUpdate |
+| **HASwitch** | 1 | transition (auto-transition toggle) |
+| **HASensor** | 10-11 | curApp, myOwnID, temp, hum, lux, signal, version, ram, uptime, ipAddr, battery* |
+| **HABinarySensor** | 3 | btnleft, btnmid, btnright |
+
+*battery only on ULANZI build
+
+All allocated with `new` in `setup()` when `haConfig.discovery == true`. **Known issue: never freed — see issue #4.**
+
+## MQTT Topics
+
+### Incoming (20 command suffixes)
+All prefixed with `<mqttConfig.prefix>/`:
+
+| Suffix | Action |
+|--------|--------|
+| `/notify` | `generateNotification(0, json)` |
+| `/notify/dismiss` | `dismissNotify()` |
+| `/custom/#` | `parseCustomPage(appName, json)` — wildcard |
+| `/switch` | `switchToApp(json)` |
+| `/apps` | `updateAppVector(json)` |
+| `/nextapp`, `/previousapp` | Navigation |
+| `/settings` | `setNewSettings(json)` |
+| `/power` | `setPower(doc["power"])` |
+| `/sleep` | `setPower(false)` + `sleep(seconds)` |
+| `/indicator1-3` | `indicatorParser(N, json)` |
+| `/moodlight` | `moodlight(json)` |
+| `/rtttl`, `/sound`, `/r2d2` | Audio playback |
+| `/doupdate` | `checkUpdate()` + `updateFirmware()` |
+| `/sendscreen` | Publish `ledsAsJson()` |
+| `/reboot` | `ESP.restart()` |
+
+Routing via `MessageRouter::routeTopic()` → `MqttCommandType` enum → switch dispatch.
+
+### Outgoing
+| Topic | Trigger |
+|-------|---------|
+| `<prefix>/stats` | Periodic (every `statsInterval` ms) |
+| `<prefix>/stats/currentApp` | On app change (deduplicated) |
+| `<prefix>/stats/effects` | On connect |
+| `<prefix>/stats/transitions` | On connect |
+| `<prefix>/button/left\|select\|right` | On hardware press (debounced) |
+
+### External Topic Caching
+- `subscribe(topic)` — registers in `mqttValues` map, subscribes on connect
+- `getValueForTopic(topic)` → cached value or "N/A"
+- Used by custom apps: `{{topic}}` placeholders resolved via PlaceholderUtils
+
+## 7 Callback Handlers (MQTTManager_Callbacks.cpp)
+
+| Callback | Entities | Action |
+|----------|----------|--------|
+| `onButtonCommand` | dismiss, nextApp, prevApp, doUpdate | Dispatch to managers |
+| `onSwitchCommand` | transition | Toggle autoTransition + save |
+| `onSelectCommand` | BriMode, transEffect | Set mode/effect + save |
+| `onRGBColorCommand` | Matrix, Indicator1-3 | Set color + save |
+| `onStateCommand` | Matrix, Indicator1-3 | Set power/state |
+| `onBrightnessCommand` | Matrix | Set brightness (skip if auto) + save |
+| `onNumberCommand` | scrollSpeed | Set scroll speed + save |
+
+All callbacks call `saveSettings()` after modifying config structs.
+
+## Connection Lifecycle
+
+```
+setup() → create 25 HA entities (if discovery enabled) → register callbacks
+  └→ connect() → mqtt.begin(host, port, user, pass)
+       └→ onMqttConnected()
+            ├─ Subscribe to ~20 command topics (30ms delay each)
+            ├─ Subscribe to deferred external topics
+            ├─ Publish effects, transitions, version, deviceID
+            └─ connected = true
+```
+
+Reconnection handled internally by ArduinoHA. `onMqttConnected()` re-runs on each reconnect.
+
+## Services Used (from lib/services/)
+
+- `MessageRouter` — topic → command type routing
+- `HADiscovery` — entity descriptors + ID generation
+- `StatsBuilder` — telemetry → JSON
+- `PlaceholderUtils` — `{{topic}}` substitution
+
+## Key Design Patterns
+
+- **Singleton** with setter injection + assert guards
+- **Split implementation** across 7 files by domain
+- **Extern globals** for 25+ HA entity pointers (MQTTManager_internal.h)
+- **Debounced button reporting** via static state tracking
+- **Deferred subscriptions** — topics queued before connect, applied in onMqttConnected()
+- **Config persistence** — all callback handlers call `saveSettings()` immediately
+- **Stability gate** — `sendStats()` only runs if `sensorConfig.sensorsStable == true`
+
+## Wiring in main.cpp
+
+```cpp
+PeripheryManager.addButtonReporter(&MQTTManager);         // IButtonReporter
+MQTTManager.setDisplay(&DisplayManager, &DisplayManager, &DisplayManager.getNotifier());
+MQTTManager.setServices(&PeripheryManager, &PowerManager, &UpdateManager, &PeripheryManager);
+// Only initialized if MQTT configured:
+if (mqttConfig.host != "") { MQTTManager.setup(); MQTTManager.tick(); }
+```
+
+## Important Constraints
+
+- Max 26 entities (hardcoded in `HAMqtt` constructor)
+- `MQTT_MAX_PACKET_SIZE=8192` (platformio.ini build flag)
+- Firmware runs fully functional without MQTT if `mqttConfig.host == ""`
+- Entity pointers remain `nullptr` if HA discovery disabled

--- a/src/MatrixDisplayUi/CLAUDE.md
+++ b/src/MatrixDisplayUi/CLAUDE.md
@@ -1,0 +1,152 @@
+# MatrixDisplayUi — AI Reference
+
+App framework for the 32x8 LED matrix. Manages app lifecycle, animated transitions, overlays, background effects, and status indicators.
+
+## File Map
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `MatrixDisplayUi.h` | 316 | Public API, enums, callbacks, state struct |
+| `MatrixDisplayUi.cpp` | 428 | State machine, update loop, app management |
+| `MatrixDisplayUi_Transitions.cpp` | 388 | 10 transition effects + rotate helper |
+| `MatrixDisplayUi_Indicators.cpp` | 180 | 3 RGB indicators with blink/fade |
+| `MatrixDisplayUi_internal.h` | 30 | Shared globals (GIF players, transition state) |
+
+## State Machine
+
+```
+FIXED (displaying app)
+  │ ticksSinceLastStateSwitch >= ticksPerApp (auto)
+  │ or nextApp()/previousApp()/transitionToApp() (manual)
+  ▼
+IN_TRANSITION (animating)
+  │ ticksSinceLastStateSwitch >= ticksPerTransition
+  ▼
+FIXED (next app)
+```
+
+### State (MatrixDisplayUiState)
+```cpp
+AppState appState;           // FIXED or IN_TRANSITION
+uint8_t currentApp;          // Active app index
+int8_t appTransitionDirection; // +1 forward, -1 backward
+bool manualControl;          // True when user-triggered
+unsigned long ticksSinceLastStateSwitch;
+```
+
+## Rendering Pipeline (per tick)
+
+```
+1. matrix->clear()
+2. Background effect (if BackgroundEffect > -1)
+3. App rendering (drawApp)
+   ├─ FIXED: AppFunctions[currentApp](matrix, state, 0, 0, gif1)
+   └─ IN_TRANSITION: transition effect blending old ↔ new app
+4. Overlays (drawOverlays) — menu, notifications, status
+5. Indicators (drawIndicators) — 3 corner RGB LEDs
+6. Global weather overlay (if set)
+7. host_->gammaCorrection()
+8. matrix->show()
+```
+
+## 10 Transition Effects
+
+| Enum | Effect | Description |
+|------|--------|-------------|
+| SLIDE (1) | Vertical slide | Direction via appAnimationDirection |
+| FADE (2) | Fade through black | Quadratic easing |
+| ZOOM (3) | Scale to/from center | Center (16,4) |
+| ROTATE (4) | 360° spin | Around center (16,4) |
+| PIXELATE (5) | Random pixel dissolve | Per-pixel probability |
+| CURTAIN (6) | Center-outward wipe | Reveals from center |
+| RIPPLE (7) | Checkerboard dissolve | Even/odd pixel pattern |
+| BLINK (8) | 3 flashes | With black gaps |
+| RELOAD (9) | Horizontal wipe | Right-out, then left-in |
+| CROSSFADE (10) | Linear pixel blend | lerp8 per pixel |
+
+RANDOM (0) selects a random effect per cycle.
+
+Progress: `ticksSinceLastStateSwitch / ticksPerTransition` (0.0 → 1.0)
+
+## App Framework
+
+### Callback Types
+```cpp
+// App: renders one page on the matrix
+using AppCallback = std::function<void(FastLED_NeoMatrix*, MatrixDisplayUiState*, int16_t x, int16_t y, GifPlayer*)>;
+
+// Overlay: drawn on top of current app every frame
+typedef void (*OverlayCallback)(FastLED_NeoMatrix*, MatrixDisplayUiState*, GifPlayer*);
+
+// Background: drawn behind all apps
+typedef void (*BackgroundCallback)(FastLED_NeoMatrix*);
+```
+
+### App Management
+```cpp
+void setApps(const vector<pair<String, AppCallback>>&);  // Register all apps
+void nextApp();           // Transition forward (FIXED state only)
+void previousApp();       // Transition backward (FIXED state only)
+bool switchToApp(uint8_t); // Instant switch, no animation
+void transitionToApp(uint8_t); // Animated transition to specific app
+```
+
+### Timing
+```cpp
+void setTargetFPS(uint8_t fps);          // Default ~30 FPS (33ms interval)
+void setTimePerApp(long ms);             // How long each app displays
+void setTimePerTransition(uint16_t ms);  // Transition animation duration
+```
+
+Default: ~5s per app, ~500ms per transition at 30 FPS.
+
+## Indicators (3 RGB LEDs)
+
+| Indicator | Position | Default Color |
+|-----------|----------|---------------|
+| 1 | Top-right (31,0), (30,0), (31,1) | Red |
+| 2 | Mid-right (31,3), (31,4) | Green |
+| 3 | Bottom-right (31,7), (31,6), (30,7) | Blue |
+
+Each supports 3 modes:
+- **Solid** — blink=0, fade=0
+- **Blink** — toggles on/off every `blink` ms
+- **Fade** — sine-wave brightness oscillation over `fade` ms
+
+```cpp
+void setIndicator{1,2,3}Color(uint32_t);
+void setIndicator{1,2,3}State(bool);
+void setIndicator{1,2,3}Blink(int ms);
+void setIndicator{1,2,3}Fade(int ms);
+```
+
+## Effects & Overlays
+
+```cpp
+void setBackground(BackgroundCallback fn);     // Register background renderer
+void setBackgroundEffect(int effect);          // Activate by index, -1 = none
+void setOverlays(OverlayCallback* arr, uint8_t count);  // Register overlay array
+void setGlobalOverlay(OverlayEffect e);        // Weather overlay on all apps
+```
+
+## Ownership
+
+```
+DisplayManager_ (creates and owns MatrixDisplayUi)
+  └── MatrixDisplayUi
+        ├── receives: FastLED_NeoMatrix* (not owned)
+        ├── receives: IMatrixHost* (not owned, = DisplayManager_)
+        ├── owns: AppCallback vector
+        ├── owns: gif1, gif2 (GifPlayer instances)
+        └── receives: overlay/background function pointers (not owned)
+```
+
+## IMatrixHost Dependency
+
+MatrixDisplayUi calls back to its host (DisplayManager_) for:
+```cpp
+CRGB* getLeds();              // Access LED buffer (for transitions)
+void gammaCorrection();       // Apply brightness curve
+void sendAppLoop();           // Notify app list changed
+bool setAutoTransition(bool); // Called after setApps()
+```


### PR DESCRIPTION
## Summary
- Add detailed AI reference documentation (CLAUDE.md) for 11 core modules
- Expand root CLAUDE.md with dependency graph, interface wiring map, data flow diagram, and service consumption map
- Total: +1910 lines of structured documentation across the project

## Modules covered
interfaces, services, config, webserver, home-assistant-integration, DisplayManager, MQTTManager, MatrixDisplayUi, DataFetcher, ServerManager, PeripheryManager, MenuManager, UpdateManager, PowerManager, Globals, AppContentRenderer