### PR TITLE
chore: add Claude Code commands and commit linting

### DIFF
--- a/.claude/commands/add-effect.md
+++ b/.claude/commands/add-effect.md
@@ -1,0 +1,62 @@
+---
+description: Add a new visual effect following the IPixelCanvas pattern
+---
+
+Guide through adding a new visual effect to the Svitrix firmware. Currently there are 19 effects.
+
+## Before starting
+
+1. **Read current effects documentation:**
+   - `src/effects/README.md` — effect architecture, IPixelCanvas API, registration
+   - `lib/interfaces/CLAUDE.md` — IPixelCanvas interface definition
+
+2. **Ask the user:**
+   - Effect name and visual description
+   - Category: pattern, wave, weather overlay, or game effect
+   - Parameters: speed, color palette, density, etc.
+   - Whether it uses noise functions (inoise8), palettes, or simple math
+
+## Implementation steps
+
+3. **Create effect function:**
+   - Add new `.cpp` file in `src/effects/` (or add to existing category file)
+   - Function signature follows the pattern:
+     ```cpp
+     void effectName(IPixelCanvas& canvas, uint8_t speed, const CRGBPalette16& palette);
+     ```
+   - Use `IPixelCanvas` methods: `setPixel()`, `getWidth()`, `getHeight()`, `fill()`
+   - Never access FastLED or NeoMatrix directly — always go through IPixelCanvas
+
+4. **Register the effect:**
+   - Add to the effect registry/list in the effects system
+   - Assign an effect ID (check existing IDs to avoid conflicts)
+   - Add to the effect name mapping
+
+5. **Add test** (if pure logic):
+   - Add test in `test/test_native/test_effects/`
+   - Use MockDisplay for IPixelCanvas mock
+   - Test edge cases: speed=0, speed=255, single pixel canvas
+
+6. **Wire to DisplayManager:**
+   - Effect should be selectable via MQTT and REST API
+   - Check that `DisplayManager_` can invoke the new effect
+
+7. **Build and verify:**
+   ```bash
+   pio test -e native_test && pio run -e ulanzi
+   ```
+   IMPORTANT: Check flash size after — effects add to binary size.
+
+8. **Update documentation:**
+   - Update `src/effects/README.md` — add effect to the list
+   - Update effect count in root `CLAUDE.md` (currently says 19)
+
+## IPixelCanvas API reference (quick)
+```cpp
+void setPixel(int16_t x, int16_t y, CRGB color);
+CRGB getPixel(int16_t x, int16_t y);
+int16_t getWidth();   // 32
+int16_t getHeight();  // 8
+void fill(CRGB color);
+void clear();
+```

--- a/.claude/commands/add-ha-entity.md
+++ b/.claude/commands/add-ha-entity.md
@@ -1,0 +1,65 @@
+---
+description: Step-by-step guide to add a new Home Assistant entity with MQTT auto-discovery
+---
+
+Guide through adding a new Home Assistant entity to the Svitrix firmware. Currently there are 25 HA entities.
+
+## Before starting
+
+1. **Read current HA integration docs:**
+   - `src/MQTTManager/CLAUDE.md` — current entities, topics, callbacks
+   - `lib/home-assistant-integration/CLAUDE.md` — enabled entity types
+   - `lib/services/CLAUDE.md` — HADiscovery service API
+
+2. **Ask the user:**
+   - Entity type: `sensor`, `switch`, `number`, `button`, `light`, `select`, or `text`
+   - Entity name and purpose
+   - Value range (for number), options (for select), unit (for sensor)
+   - Whether it needs a command topic (writeable from HA) or is read-only
+
+## Implementation steps
+
+3. **Add entity descriptor** to `lib/services/HADiscovery/`:
+   - Add a new `HAEntityDescriptor` to the descriptors array
+   - Follow the existing pattern: name, unique_id, component type, config fields
+   - Add test for the new descriptor in `test/test_native/test_ha_discovery/`
+
+4. **Add MQTT command handler** (if entity is writeable):
+   - Add route to `lib/services/MessageRouter/`
+   - Add handler function in `src/MQTTManager/MQTTManager_callbacks.cpp`
+   - Add test for the route in `test/test_native/test_message_router/`
+
+5. **Add state publishing:**
+   - In `src/MQTTManager/MQTTManager_.cpp` — publish entity state in the stats cycle
+   - Use the existing `publishState()` pattern
+
+6. **Wire in DisplayManager** (if entity affects display):
+   - Add config field in `lib/config/ConfigTypes.h` if needed
+   - Read `lib/config/CLAUDE.md` for config struct conventions
+   - Handle the new setting in `src/DisplayManager/`
+
+7. **Run tests:**
+   ```bash
+   pio test -e native_test
+   ```
+
+8. **Build and verify:**
+   ```bash
+   pio run -e ulanzi
+   ```
+
+9. **Update documentation:**
+   - Update `src/MQTTManager/CLAUDE.md` — add entity to the list
+   - Update entity count in root `CLAUDE.md` if needed
+
+## Checklist
+- [ ] HAEntityDescriptor added
+- [ ] Test for descriptor added
+- [ ] MQTT command handler added (if writeable)
+- [ ] Test for command handler added
+- [ ] State publishing added
+- [ ] Config struct updated (if needed)
+- [ ] DisplayManager integration (if needed)
+- [ ] All tests pass
+- [ ] Build succeeds
+- [ ] CLAUDE.md updated

--- a/.claude/commands/add-service.md
+++ b/.claude/commands/add-service.md
@@ -1,0 +1,136 @@
+---
+description: Step-by-step guide to add a new stateless service library to lib/services/
+---
+
+Add a new service library to `lib/services/` following the project's architecture conventions.
+
+## Prerequisites
+
+Before starting, the user should specify:
+- **Service name** (PascalCase, e.g., `ColorUtils`, `SensorCalc`)
+- **Purpose** — what the service does
+- **Key methods** — what API it exposes
+
+If not provided, ask the user.
+
+## Steps
+
+1. **Verify the name doesn't conflict:**
+   ```bash
+   ls lib/services/src/
+   ```
+   Check that no existing service has the same or similar name.
+
+2. **Create the header file** `lib/services/src/<ServiceName>.h`:
+   ```cpp
+   #pragma once
+
+   #ifdef UNIT_TEST
+   #include <cstdint>
+   // Add other standard includes as needed
+   #else
+   #include <Arduino.h>
+   #endif
+
+   // Service API — all functions must be stateless (pure functions)
+   // Pass time/state as parameters, don't call millis() or read globals
+   ```
+
+   **Rules for the header:**
+   - `#pragma once` guard
+   - `#ifdef UNIT_TEST` block for native test compatibility (no Arduino dependency)
+   - All functions should be stateless — pass time/state as parameters
+   - Prefer `const char*` params where possible, `String` for Arduino compat
+   - No ArduinoJson dependency — build JSON manually if needed
+   - No hardware includes — must compile in `native_test` environment
+
+3. **Create the implementation** `lib/services/src/<ServiceName>.cpp`:
+   - Include only the header and standard libs
+   - Keep functions pure — deterministic, no side effects
+   - Use `std::function` or function pointers for callback injection if needed
+
+4. **Create the test suite** `test/test_native/test_<snake_case>/test_<snake_case>.cpp`:
+   ```cpp
+   #include <unity.h>
+   #include "<ServiceName>.h"
+
+   void setUp() {}
+   void tearDown() {}
+
+   void test_<descriptive_name>()
+   {
+       // Arrange
+       // Act
+       // Assert
+       TEST_ASSERT_...;
+   }
+
+   int main()
+   {
+       UNITY_BEGIN();
+       RUN_TEST(test_<descriptive_name>);
+       return UNITY_END();
+   }
+   ```
+
+   **Test rules:**
+   - 100% coverage target — test every public function
+   - Test edge cases: empty strings, zero values, null pointers, overflow
+   - Use Unity framework (`TEST_ASSERT_*` macros)
+   - No mocks needed for stateless services (that's the point)
+
+5. **Run tests:**
+   ```bash
+   pio test -e native_test
+   ```
+   Verify new tests pass and existing tests are not broken.
+
+6. **Update documentation:**
+
+   **lib/services/CLAUDE.md** — add to the Service Map table:
+   ```
+   | **<ServiceName>** | <purpose> | Yes | `<method1>()`, `<method2>()` |
+   ```
+   Also update:
+   - Dependency Graph section (if it depends on other services)
+   - Who Uses What table (which module will consume it)
+   - Test Coverage table
+   - Update the service count in the header line
+
+   **Root CLAUDE.md** — update:
+   - Service count in Project Structure (`lib/services/` line)
+   - Service count in LIBRARIES box
+   - Service consumption map (add consumer entry)
+
+7. **Wire it up** in the consuming module:
+   - Add `#include "<ServiceName>.h"` in the consumer
+   - Call service functions (no injection needed for stateless services)
+
+8. **Verify build:**
+   ```bash
+   pio run -e ulanzi
+   ```
+   Check binary size delta — report it.
+
+9. **Report:**
+   ```
+   === New Service Report ===
+   Service: <ServiceName>
+   Files created:
+   - lib/services/src/<ServiceName>.h
+   - lib/services/src/<ServiceName>.cpp
+   - test/test_native/test_<snake_case>/test_<snake_case>.cpp
+
+   Tests: X new tests, all passing
+   Binary size: +Y bytes (Z.Z%)
+   Docs updated: lib/services/CLAUDE.md, CLAUDE.md (root)
+   ```
+
+## Design Principles (from lib/services/CLAUDE.md)
+
+1. **Keep stateless** — pass time/state as parameters, don't call `millis()` or read globals
+2. **Add tests** in `test/test_native/test_<name>/` — maintain 100% coverage
+3. **Use Arduino `String`** for compatibility but prefer `const char*` params where possible
+4. **No ArduinoJson** — build JSON manually for native test compatibility
+5. **No hardware includes** — services must compile in `native_test` environment
+6. **Update the docs** when created

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,38 @@
+---
+description: Full local CI pipeline — tests, build, flash size check
+---
+
+Run the complete local CI pipeline for Svitrix firmware. Execute each step sequentially, stop on first failure.
+
+## Steps
+
+1. **Run all unit tests:**
+   ```bash
+   pio test -e native_test
+   ```
+   Report: total suites, total tests, pass/fail count.
+   If any test fails — STOP and report which suite failed.
+
+2. **Build firmware:**
+   ```bash
+   pio run -e ulanzi
+   ```
+   This also triggers the web SPA pre-build via `tools/build_web.py`.
+   If build fails — STOP and report the error.
+
+3. **Check flash size:**
+   After successful build, check `.pio/build/ulanzi/firmware.bin` size.
+   Read the build output for RAM/Flash usage summary.
+   
+   Thresholds (firmware partition is ~3.8MB):
+   - **< 90%**: OK
+   - **90-95%**: WARNING — flash space getting tight
+   - **> 95%**: CRITICAL — must optimize before adding features
+
+4. **Summary report:**
+   ```
+   Tests:     24 suites, XXX tests passed
+   Build:     OK
+   Firmware:  XXX KB / 3932 KB (XX%)
+   Status:    OK | WARNING | CRITICAL
+   ```

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,0 +1,112 @@
+---
+description: Generate changelog from conventional commits — for a release, range, or since last tag
+---
+
+Generate a structured changelog from git commit history using Conventional Commits format.
+
+## Input
+
+The user may specify:
+- A version tag: `/changelog v0.2.0` → commits since previous tag to v0.2.0
+- A range: `/changelog v0.1.0..HEAD` → commits in that range
+- Nothing: `/changelog` → commits since the last tag to HEAD
+
+## Steps
+
+1. **Determine commit range:**
+   ```bash
+   # Find the last tag
+   git describe --tags --abbrev=0 HEAD 2>/dev/null
+   # Find the previous tag (for a specific release)
+   git describe --tags --abbrev=0 <tag>^ 2>/dev/null
+   ```
+   If no tags exist, use all commits on the current branch.
+
+2. **Collect commits:**
+   ```bash
+   git log <range> --oneline --no-merges
+   ```
+
+3. **Parse each commit** according to Conventional Commits:
+   - Extract: type, scope (optional), breaking change flag, description
+   - Skip merge commits
+   - Group by type into changelog sections
+
+4. **Generate changelog** in this format:
+
+   ```markdown
+   ## [v0.2.0] — YYYY-MM-DD
+
+   ### Breaking Changes
+   - **scope:** description (#PR)
+
+   ### Features
+   - **scope:** description (#PR)
+
+   ### Bug Fixes
+   - **scope:** description (#PR)
+
+   ### Performance
+   - **scope:** description (#PR)
+
+   ### Other Changes
+   - **type(scope):** description
+   ```
+
+   **Section mapping:**
+   | Commit type | Changelog section |
+   |-------------|-------------------|
+   | `feat` | Features |
+   | `fix` | Bug Fixes |
+   | `perf` | Performance |
+   | Breaking (`!` or `BREAKING CHANGE:`) | Breaking Changes (always first) |
+   | `refactor`, `docs`, `test`, `chore`, `build`, `ci`, `style` | Other Changes |
+
+   **Rules:**
+   - Omit empty sections
+   - If scope is present, bold it: `- **mqtt:** add light entity support`
+   - If no scope: `- add temperature overlay`
+   - Link PR/issue numbers if present in commit message
+   - Sort entries alphabetically by scope within each section
+
+5. **Output options:**
+   - Print to terminal (default)
+   - If user says "save" or "write": append/prepend to `CHANGELOG.md` in project root
+   - If `CHANGELOG.md` doesn't exist, create it with a header:
+     ```markdown
+     # Changelog
+
+     All notable changes to this project will be documented in this file.
+     Format based on [Keep a Changelog](https://keepachangelog.com/) and
+     [Conventional Commits](https://www.conventionalcommits.org/).
+     ```
+
+6. **Report:**
+   ```
+   Changelog for v0.1.0..HEAD (12 commits):
+   - 3 features, 2 fixes, 1 perf, 6 other
+   - 0 breaking changes
+   ```
+
+## Example output
+
+```markdown
+## [v0.2.0] — 2026-04-15
+
+### Features
+- **datafetcher:** add JSON path array index support
+- **mqtt:** add light entity support
+- **web:** migrate web UI to Preact SPA
+
+### Bug Fixes
+- **display:** prevent crash on empty notification text
+- **mqtt:** free HA entity memory before re-allocation
+
+### Performance
+- **display:** reduce DisplayRenderer draw calls
+
+### Other Changes
+- chore: upgrade C++ standard from C++11 to C++17
+- docs: sync documentation with feature branch changes
+- test: add UnicodeFont edge cases
+```

--- a/.claude/commands/flash-size.md
+++ b/.claude/commands/flash-size.md
@@ -1,0 +1,66 @@
+---
+description: Analyze firmware binary size and partition layout in detail
+---
+
+Perform a detailed analysis of the firmware flash usage. This is critical — flash is ~96% full.
+
+## Steps
+
+1. **Build firmware** (if not recently built):
+   ```bash
+   pio run -e ulanzi
+   ```
+
+2. **Get firmware binary size:**
+   ```bash
+   stat -f%z .pio/build/ulanzi/firmware.bin 2>/dev/null || stat -c%s .pio/build/ulanzi/firmware.bin
+   ```
+
+3. **Parse build output** for section sizes:
+   Look for the RAM/Flash usage line in the build output, e.g.:
+   ```
+   RAM:   [===       ]  XX.X% (used XXXXX bytes from 327680 bytes)
+   Flash: [========= ]  XX.X% (used XXXXXXX bytes from 3932160 bytes)
+   ```
+
+4. **Read partition table:**
+   ```bash
+   cat svitrix_partition.csv
+   ```
+   Show each partition: name, type, offset, size.
+
+5. **Analyze LittleFS usage:**
+   ```bash
+   ls -la data/web/
+   ```
+   Total size of web assets in LittleFS.
+
+6. **Section breakdown** (if available):
+   ```bash
+   pio run -e ulanzi -t size
+   ```
+   Show .text, .data, .rodata, .bss sizes.
+
+7. **Report:**
+   ```
+   === Flash Usage Report ===
+   
+   Firmware partition:  3,932 KB total
+   Firmware binary:     X,XXX KB (XX.X%)
+   Free space:          XXX KB
+   
+   LittleFS partition:  256 KB total
+   Web assets:          XXX KB
+   Icons/data:          XXX KB
+   
+   RAM usage:           XXX KB / 320 KB (XX.X%)
+   
+   Status: OK | WARNING (>90%) | CRITICAL (>95%)
+   ```
+
+8. **If CRITICAL**, suggest optimization strategies:
+   - Check for unused effects (19 effects may not all be needed)
+   - Check for large string literals or lookup tables
+   - Review lib_deps for unused libraries
+   - Consider `-Os` vs `-Oz` optimization
+   - Check if games are accidentally included (should be excluded by build_src_filter)

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,93 @@
+---
+description: Create a well-formatted GitHub PR from the current feature branch
+---
+
+Create a GitHub Pull Request from the current feature branch to main with a structured description.
+
+## Steps
+
+1. **Gather context:**
+   ```bash
+   git branch --show-current
+   git log --oneline main..HEAD
+   git diff --stat main..HEAD
+   git diff main..HEAD
+   ```
+   Verify we're on a `feature/*` branch (not main). If on main — abort with a message.
+
+2. **Ensure branch is pushed:**
+   ```bash
+   git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+   ```
+   If no upstream — push with `git push -u origin <branch>`.
+
+3. **Analyze all commits** (not just the latest!) and changed files:
+   - Group changes by type (feat, fix, refactor, etc.)
+   - Identify breaking changes
+   - Note affected modules (from file paths)
+   - Check if tests were added/updated
+   - Check binary size impact if firmware files changed
+
+4. **Generate PR title:**
+   - If single feat/fix commit: use that commit's subject line
+   - If multiple commits of same type: summarize as single conventional commit
+   - If mixed types: use the most significant change as title
+   - Keep under 70 characters
+   - Format: `<type>[(scope)]: <description>`
+
+5. **Generate PR body** using this template:
+
+   ```markdown
+   ## Summary
+   
+   <2-4 bullet points describing what this PR does and WHY>
+   
+   ## Changes
+   
+   <grouped by type, one bullet per logical change>
+   
+   ### Features
+   - description
+   
+   ### Bug Fixes
+   - description
+   
+   ### Other
+   - description
+   
+   ## Breaking Changes
+   
+   <only if applicable, otherwise omit section>
+   
+   ## Binary Size
+   
+   <if firmware .cpp/.h files changed>
+   - Before: X bytes
+   - After: Y bytes  
+   - Delta: +/- Z bytes (X.X%)
+   
+   ## Test Plan
+   
+   - [ ] `pio test -e native_test` passes
+   - [ ] `pio run -e ulanzi` builds successfully
+   - [ ] Binary size within partition limit
+   - [ ] <specific test items based on changes>
+   ```
+
+6. **Create the PR:**
+   ```bash
+   gh pr create --title "<title>" --body "<body>" --base main
+   ```
+   Use a HEREDOC for the body to preserve formatting.
+
+7. **Report:**
+   Print the PR URL so the user can review it.
+
+## Rules
+
+- Omit empty sections (no "### Bug Fixes" if there are none)
+- Binary Size section only if .cpp/.h/.ino files were changed
+- Breaking Changes section only if any commit has `!` or `BREAKING CHANGE:`
+- Test Plan checkboxes should be specific to the actual changes
+- If the branch has only doc/config changes, simplify the template accordingly
+- Do NOT auto-merge — just create the PR

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,49 @@
+---
+description: Interactive release workflow — beta, rc, or stable
+---
+
+Guide through the Svitrix firmware release process following the project's semver conventions.
+
+## Steps
+
+1. **Check prerequisites:**
+   - `git status` must be clean (no uncommitted changes)
+   - All tests pass: `pio test -e native_test`
+   - Build succeeds: `pio run -e ulanzi`
+   - If any check fails — STOP and report.
+
+2. **Determine release type:**
+   Ask the user: **beta**, **rc**, or **stable**?
+
+3. **Calculate next version:**
+   - List existing tags: `git tag --sort=-v:refname | head -20`
+   - Based on the latest tag and release type, calculate next version:
+     - If latest is `v0.2.0` and type is beta → `v0.3.0-beta.1`
+     - If latest is `v0.3.0-beta.1` and type is beta → `v0.3.0-beta.2`
+     - If latest is `v0.3.0-beta.2` and type is rc → `v0.3.0-rc.1`
+     - If latest is `v0.3.0-rc.1` and type is rc → `v0.3.0-rc.2`
+     - If latest is `v0.3.0-rc.2` and type is stable → `v0.3.0`
+   - Show calculated version and ask user to confirm or override.
+
+4. **Generate release notes:**
+   - `git log --oneline <last-stable-tag>..HEAD`
+   - Group commits by type (feat, fix, refactor, docs, etc.)
+   - Present formatted release notes for review.
+
+5. **Create annotated tag:**
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z: <short description>"
+   ```
+   IMPORTANT: Use annotated tags only (`-a` flag).
+
+6. **Show next steps** (do NOT execute automatically):
+   ```
+   Push tag:     git push origin vX.Y.Z
+   Push branch:  git push origin <branch>
+   ```
+   The CI pipeline (`main.yml`) will automatically:
+   - Build firmware with version embedded
+   - Create GitHub Release (pre-release for beta/rc)
+   - Attach firmware.bin
+
+7. **Remind:** beta and rc tags should be created on feature branches. Stable tags go on `main` after PR merge.

--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -1,0 +1,92 @@
+---
+description: Sync all CLAUDE.md and README.md docs with branch changes — run before PR or periodically on feature branches
+---
+
+Analyze ALL changes on the current feature branch vs main and update every affected documentation file to reflect the actual state of the code.
+
+## Steps
+
+1. **Identify branch and all changes:**
+   ```bash
+   git log --oneline main..HEAD
+   git diff --stat main..HEAD
+   git diff --name-only main..HEAD
+   ```
+   If on `main` — use `HEAD~5` instead.
+   Report: number of commits, files changed, summary of what was done.
+
+2. **Map changed files to documentation** using this table:
+
+   | Changed files in... | Doc to update |
+   |---------------------|---------------|
+   | `src/DisplayManager/` | `src/DisplayManager/CLAUDE.md` |
+   | `src/MQTTManager/` | `src/MQTTManager/CLAUDE.md` |
+   | `src/MatrixDisplayUi/` | `src/MatrixDisplayUi/CLAUDE.md` |
+   | `src/DataFetcher/` | `src/DataFetcher/CLAUDE.md` |
+   | `src/Apps/` | `src/Apps/README.md` |
+   | `src/Games/` | `src/Games/README.md` |
+   | `src/MelodyPlayer/` | `src/MelodyPlayer/README.md` |
+   | `src/effects/` | `src/effects/README.md` |
+   | `src/ServerManager.*`, `src/PeripheryManager.*`, `src/MenuManager.*`, `src/Globals.*`, `src/AppContentRenderer.*`, `src/PowerManager.*`, `src/UpdateManager.*` | `src/CLAUDE.md` |
+   | `lib/interfaces/` | `lib/interfaces/CLAUDE.md` |
+   | `lib/services/` | `lib/services/CLAUDE.md` |
+   | `lib/config/` | `lib/config/CLAUDE.md` |
+   | `lib/home-assistant-integration/` | `lib/home-assistant-integration/CLAUDE.md` |
+   | `lib/webserver/` | `lib/webserver/CLAUDE.md` |
+   | `web/` | `web/README.md` |
+   | `platformio.ini`, `main.cpp`, new modules, interface changes | Root `CLAUDE.md` |
+   | `test/` | Update test counts in relevant docs |
+   | `.claude/` | Root `CLAUDE.md` (if orchestrator section exists) |
+
+3. **For each affected doc — read code, then update doc:**
+   - Read the changed source files (`git diff main..HEAD -- <path>`)
+   - Read the current doc file
+   - Update ONLY sections affected by the changes:
+     - New/removed/renamed classes, methods, interfaces, config fields
+     - Changed function signatures, behaviors, endpoints
+     - New MQTT topics or HA entities
+     - New effects, apps, or test suites
+     - Changed dependency wiring in `main.cpp`
+
+4. **Update counts across all docs:**
+   Verify these numbers match reality:
+   - HA entities count (currently 25) — check `src/MQTTManager/`
+   - Effects count (currently 19) — check `src/effects/`
+   - API endpoints count — check `src/ServerManager.cpp`
+   - Test suites/tests count — run `pio test -e native_test --list-tests` or count test files
+   - Interface count (currently 13) — check `lib/interfaces/`
+   - Service count (currently 13) — check `lib/services/`
+
+5. **Update root CLAUDE.md if architecture changed:**
+   - New module added → update Project Structure tree
+   - New interface → update Module Dependency Graph + Interface wiring table
+   - New service → update Service consumption map
+   - New CLAUDE.md file → update CLAUDE.md reference map
+
+6. **Report:**
+   ```
+   === Docs Sync Report ===
+   Branch: feature/xxx (N commits ahead of main)
+   
+   Updated:
+   - src/MQTTManager/CLAUDE.md — added new entity X, updated topic list
+   - lib/services/CLAUDE.md — added new service Y
+   - CLAUDE.md (root) — updated entity count 25→26
+   
+   No changes needed:
+   - src/DisplayManager/CLAUDE.md
+   - ...
+   
+   Counts verified:
+   - HA entities: 26 ✓
+   - Effects: 19 ✓
+   - Tests: 24 suites, 440 tests ✓
+   ```
+
+## Important rules
+- Do NOT rewrite docs from scratch — update incrementally
+- Preserve existing structure and formatting
+- Compare against ACTUAL code, not just diff — the diff shows what changed, but the doc must reflect final state
+- If a doc section references code that no longer exists — remove it
+- If new code has no doc coverage — add a section for it
+- Commit doc updates separately: `docs: sync documentation with feature/xxx changes`

--- a/.claude/commands/sync-public-docs.md
+++ b/.claude/commands/sync-public-docs.md
@@ -1,0 +1,112 @@
+---
+description: Sync public VitePress documentation (docs/) with code changes — run before release or periodically on feature branches
+---
+
+Analyze ALL changes on the current feature branch vs main and update every affected public documentation file in `docs/` to reflect the actual state of the code.
+
+## Context
+
+Public docs live in `docs/` (VitePress, deployed to GitHub Pages). English docs at root, Ukrainian translations in `docs/uk/`. Both languages MUST stay in sync.
+
+## Steps
+
+1. **Identify branch and all changes:**
+   ```bash
+   git log --oneline main..HEAD
+   git diff --stat main..HEAD
+   git diff --name-only main..HEAD
+   ```
+   If on `main` — use `HEAD~5` instead.
+   Report: number of commits, files changed, summary of what was done.
+
+2. **Map changed files to public documentation** using this table:
+
+   | Changed files in... | Docs to update (EN + UK) |
+   |---------------------|--------------------------|
+   | `src/Apps/`, `src/DisplayManager/DisplayManager_CustomApps.cpp` | `docs/apps.md`, `docs/uk/apps.md` |
+   | `src/effects/`, `src/effects/EffectRegistry.*` | `docs/effects.md`, `docs/uk/effects.md` |
+   | `src/ServerManager.*`, `src/MQTTManager/` | `docs/api.md`, `docs/uk/api.md` |
+   | `web/src/` | `docs/webinterface.md`, `docs/uk/webinterface.md` |
+   | `src/Globals.cpp`, `lib/config/` | `docs/dev.md`, `docs/uk/dev.md` |
+   | `src/DataFetcher/` | `docs/datafetcher.md`, `docs/uk/datafetcher.md` |
+   | `src/MelodyPlayer/` | `docs/sounds.md`, `docs/uk/sounds.md` |
+   | `src/PeripheryManager.*`, `platformio.ini` (GPIO/hardware) | `docs/hardware.md`, `docs/uk/hardware.md` |
+   | `src/MenuManager.*` | `docs/onscreen.md`, `docs/uk/onscreen.md` |
+   | `lib/webserver/`, backup-related changes | `docs/backup.md`, `docs/uk/backup.md` |
+   | Partition layout, flashing workflow | `docs/flasher.md`, `docs/uk/flasher.md` |
+   | New features, setup flow changes | `docs/quickstart.md`, `docs/uk/quickstart.md` |
+   | New pages in SPA, navigation changes | `docs/.vitepress/config.mts` |
+
+3. **For each affected doc — read code, then update doc:**
+   - Read the changed source files (`git diff main..HEAD -- <path>`)
+   - Read the current English doc file
+   - Read the corresponding Ukrainian doc file
+   - Update ONLY sections affected by the changes:
+     - New/removed/renamed API endpoints (MQTT topics + HTTP routes)
+     - New/changed JSON payload fields
+     - New effects, apps, or menu items
+     - Changed settings keys or default values
+     - New web UI pages or controls
+     - Changed hardware pinout or sensor support
+
+4. **Verify key counts and lists in docs match code:**
+
+   | What | Where to check | Docs that reference it |
+   |------|---------------|----------------------|
+   | Effects list + count | `src/effects/EffectRegistry.cpp` | `docs/effects.md` |
+   | MQTT topics | `src/MQTTManager/MQTTManager_Messages.cpp` | `docs/api.md` |
+   | HTTP endpoints | `src/ServerManager.cpp` | `docs/api.md` |
+   | Custom app JSON fields | `src/DisplayManager/DisplayManager_ParseHelpers.cpp` | `docs/api.md` (Custom Apps section) |
+   | Notification JSON fields | `src/DisplayManager/NotificationManager.cpp` | `docs/api.md` (Notifications section) |
+   | Menu items | `src/MenuManager.cpp` | `docs/onscreen.md` |
+   | `dev.json` keys | `src/Globals.cpp` (`loadDevSettings()`) | `docs/dev.md` |
+   | Web UI pages | `web/src/pages/` | `docs/webinterface.md` |
+   | Native apps | `src/Apps/Apps_NativeApps.cpp` | `docs/apps.md` |
+   | Settings API keys | `src/DisplayManager/DisplayManager_Settings.cpp` | `docs/api.md` (Settings section) |
+
+5. **Ukrainian translations:**
+   - For every English doc change, apply the SAME structural change to the Ukrainian version
+   - Translate new content to Ukrainian
+   - Keep formatting, headings, and code blocks identical between EN and UK
+   - Do NOT machine-translate API field names, JSON keys, or code — keep those as-is
+
+6. **Check VitePress config if navigation changed:**
+   - New doc page added → add to sidebar in `docs/.vitepress/config.mts` (both EN and UK sections)
+   - Page renamed or removed → update sidebar links
+
+7. **Report:**
+   ```
+   === Public Docs Sync Report ===
+   Branch: feature/xxx (N commits ahead of main)
+
+   Updated (EN):
+   - docs/api.md — added new endpoint POST /api/foo, updated MQTT topic list
+   - docs/effects.md — added new effect "Aurora" (19→20)
+
+   Updated (UK):
+   - docs/uk/api.md — same changes as EN, translated
+   - docs/uk/effects.md — same changes as EN, translated
+
+   No changes needed:
+   - docs/quickstart.md
+   - docs/hardware.md
+   - ...
+
+   Counts verified:
+   - Effects in docs: 19 ✓
+   - MQTT topics in docs: 20 ✓
+   - HTTP endpoints in docs: 35 ✓
+   - Menu items in docs: 13 ✓
+   - dev.json keys in docs: 19 ✓
+   ```
+
+## Important rules
+- Do NOT rewrite docs from scratch — update incrementally
+- Preserve existing structure, formatting, and tone (user-facing, friendly)
+- Public docs use **user-facing language** (not developer jargon) — explain what things DO, not how they're implemented
+- Screenshots/GIFs in `docs/assets/` — if a visual changed significantly, note it in the report but don't generate images
+- Compare against ACTUAL code, not just diff — the diff shows what changed, but the doc must reflect final state
+- If a doc section references a feature that no longer exists — remove it
+- If new user-facing code has no doc coverage — add a section for it
+- Keep EN and UK docs structurally identical (same headings, same order, same code blocks)
+- Commit doc updates separately: `docs: sync public documentation with feature/xxx changes`

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,62 @@
+---
+description: Update CLAUDE.md documentation files after code changes
+---
+
+Scan recent code changes and update the corresponding CLAUDE.md / README.md files to keep AI documentation in sync.
+
+## Process
+
+1. **Identify what changed:**
+   ```bash
+   git diff --name-only HEAD~5
+   ```
+   Or if on a feature branch:
+   ```bash
+   git diff --name-only main...HEAD
+   ```
+
+2. **Map changes to documentation files:**
+   Use this mapping to determine which docs need updating:
+
+   | Changed files in... | Update doc |
+   |---------------------|------------|
+   | `src/DisplayManager/` | `src/DisplayManager/CLAUDE.md` |
+   | `src/MQTTManager/` | `src/MQTTManager/CLAUDE.md` |
+   | `src/MatrixDisplayUi/` | `src/MatrixDisplayUi/CLAUDE.md` |
+   | `src/DataFetcher/` | `src/DataFetcher/CLAUDE.md` |
+   | `src/Apps/` | `src/Apps/README.md` |
+   | `src/Games/` | `src/Games/README.md` |
+   | `src/MelodyPlayer/` | `src/MelodyPlayer/README.md` |
+   | `src/effects/` | `src/effects/README.md` |
+   | `src/ServerManager.*`, `src/PeripheryManager.*`, `src/MenuManager.*`, `src/Globals.*`, `src/AppContentRenderer.*` | `src/CLAUDE.md` |
+   | `lib/interfaces/` | `lib/interfaces/CLAUDE.md` |
+   | `lib/services/` | `lib/services/CLAUDE.md` |
+   | `lib/config/` | `lib/config/CLAUDE.md` |
+   | `lib/home-assistant-integration/` | `lib/home-assistant-integration/CLAUDE.md` |
+   | `lib/webserver/` | `lib/webserver/CLAUDE.md` |
+   | `web/` | `web/README.md` |
+   | Architecture changes | Root `CLAUDE.md` |
+
+3. **For each affected doc file:**
+   - Read the current doc
+   - Read the changed source files
+   - Update the doc to reflect:
+     - New/removed/renamed classes, methods, or interfaces
+     - Changed function signatures or behavior
+     - New config fields or MQTT topics
+     - Updated counts (entities, effects, endpoints, tests)
+     - New dependencies or wiring changes
+
+4. **Verify consistency:**
+   - Cross-check counts: "25 HA entities", "19 effects", "33 endpoints", etc.
+   - Verify interface lists match actual code
+   - Check that module dependency graph in root CLAUDE.md is still accurate
+
+5. **Report what was updated:**
+   List each doc file changed with a brief summary of what was updated.
+
+## Important
+- Do NOT rewrite docs from scratch — update incrementally
+- Preserve the existing structure and formatting of each doc
+- Only update sections that are affected by the code changes
+- If a doc has no changes needed, skip it

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 !tools/dist.sh
 compile_commands.json
 
+# Claude Code
+.claude/settings.json
+.claude/settings.local.json
+
 # OS
 .DS_Store
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,24 @@ repos:
         args: ['--maxkb=500']
       - id: check-merge-conflict
 
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - refactor
+          - perf
+          - docs
+          - test
+          - chore
+          - build
+          - ci
+          - style
+          - release
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:


### PR DESCRIPTION
## Summary

- Add 11 slash commands for common workflows
- Add conventional commit message validation via pre-commit hook
- Gitignore personal Claude Code settings

## Changes

### New commands (.claude/commands/)
- `/build` — full CI pipeline (tests + build + flash size)
- `/release` — interactive release workflow (beta/rc/stable)
- `/flash-size` — firmware binary size analysis
- `/changelog` — generate changelog from conventional commits
- `/pr` — create well-formatted GitHub PR
- `/sync-docs` — sync CLAUDE.md files with code
- `/sync-public-docs` — sync VitePress docs with code
- `/update-docs` — quick docs update after changes
- `/add-effect` — add new visual effect (IPixelCanvas pattern)
- `/add-ha-entity` — add new Home Assistant entity
- `/add-service` — add new stateless service to lib/services

### Commit linting
- Added `conventional-pre-commit` hook to `.pre-commit-config.yaml`
- Validates commit messages match Conventional Commits format

### Other
- Added `.claude/settings.json` and `.claude/settings.local.json` to `.gitignore`

## Test Plan

- [ ] No code changes — tooling and configuration only
- [ ] `pre-commit install --hook-type commit-msg` works