### PR TITLE
ci: auto-inject firmware version from version file

### DIFF
--- a/.claude/git-workflow.md
+++ b/.claude/git-workflow.md
@@ -85,6 +85,16 @@ v0.2.0          stable release
 5. Merge PR, tag `v0.X.0` on `main`
 6. GitHub Release from tag, attach `firmware.bin`
 
+### Version file
+
+The `version` file at the repo root is the **single source of truth** for the
+firmware version embedded into the build (via [tools/inject_version.py](../tools/inject_version.py)).
+
+- Updated automatically by the release workflow from the pushed git tag
+- Committed back to `main` as part of the `release: vX.Y.Z` auto-commit
+- **Do not edit manually** — push a tag instead
+- If missing/empty, [src/Globals.h](../src/Globals.h) falls back to `"dev"`
+
 ## GitHub Releases
 
 - **Stable** — full release, marked "Latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,13 +45,11 @@ jobs:
           pip install --upgrade platformio
           sudo apt-get -y install jq
 
-      - name: Compile firmware with version
-        env:
-          PLATFORMIO_BUILD_FLAGS: -DVERSION=\"${{ steps.version.outputs.version }}\"
-        run: pio run --environment ulanzi
-
       - name: Sync version file
         run: echo '${{ steps.version.outputs.version }}' > version
+
+      - name: Compile firmware
+        run: pio run --environment ulanzi
 
       - name: Update web flasher
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Sync version file
         run: echo '${{ steps.version.outputs.version }}' > version
 
+      - name: Verify version file matches tag
+        run: |
+          FILE_VERSION=$(cat version)
+          if [ "$FILE_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "version file ($FILE_VERSION) does not match tag (${{ steps.version.outputs.version }})"
+            exit 1
+          fi
+
       - name: Compile firmware
         run: pio run --environment ulanzi
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /Tools
 !tools/build_web.py
 !tools/dist.sh
-!tools/inject_version.py
 compile_commands.json
 
 # Claude Code

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /Tools
 !tools/build_web.py
 !tools/dist.sh
+!tools/inject_version.py
 compile_commands.json
 
 # Claude Code

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,9 @@ lib_deps =
 platform = espressif32@6.3.0
 framework = arduino
 board = esp32dev
-extra_scripts = pre:tools/build_web.py
+extra_scripts =
+	pre:tools/build_web.py
+	pre:tools/inject_version.py
 board_build.partitions = svitrix_partition.csv
 board_build.filesystem = littlefs
 build_flags =

--- a/tools/inject_version.py
+++ b/tools/inject_version.py
@@ -1,0 +1,27 @@
+"""
+PlatformIO pre-build script: reads firmware version from the `version` file
+in the project root and injects it as -DVERSION build flag.
+
+Single source of truth: the `version` file. The release workflow updates it
+from the git tag and commits it back to main, so both local and CI builds
+produce firmware reporting the correct version.
+
+If `version` is missing or empty, no flag is added — Globals.h falls back to
+"dev".
+
+Add to platformio.ini:
+    extra_scripts = pre:tools/inject_version.py
+"""
+
+import os
+
+Import("env")
+
+version_file = os.path.join(env["PROJECT_DIR"], "version")
+
+if os.path.isfile(version_file):
+    with open(version_file, "r", encoding="utf-8") as f:
+        version = f.read().strip()
+    if version:
+        env.Append(CPPDEFINES=[("VERSION", env.StringifyMacro(version))])
+        print(f"Firmware version: {version}")


### PR DESCRIPTION
## Summary

- Make the `version` file the single source of truth for firmware version.
- Local builds from `main` will now produce firmware reporting the correct version instead of the `"dev"` fallback.
- The release workflow already commits the bumped `version` file back to `main` after a tag is pushed — this PR makes that commit actually take effect in the source.

## Changes

### CI
- [.github/workflows/main.yml](.github/workflows/main.yml): write the `version` file **before** firmware compilation (was after); drop the `PLATFORMIO_BUILD_FLAGS` env override — no longer needed.

### Build
- [tools/inject_version.py](tools/inject_version.py): new pre-build script. Reads `version` file from project root and injects `-DVERSION="x.y.z"` via `CPPDEFINES`. If the file is missing/empty, no flag is added and `Globals.h` falls back to `"dev"`.
- [platformio.ini](platformio.ini): register the new script in `extra_scripts` for the `ulanzi` env.

## How releases work after this change

1. Push tag `vX.Y.Z`
2. CI extracts `X.Y.Z`, writes it to `version`
3. CI runs `pio run` → script reads `version` → firmware built with correct `-DVERSION`
4. CI commits `version` + `manifest.json` back to `main`
5. Anyone building from `main` locally also gets the correct version (not `"dev"`)

## Test Plan

- [x] `pio run -e ulanzi` builds successfully; build log shows `Firmware version: 0.2.0`
- [x] `pio test -e native_test` — 475 tests pass
- [ ] After merge: push a test tag and verify CI flow end-to-end