### PR TITLE
ci: bundle littlefs.bin (SPA) into release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,15 @@ jobs:
       - name: Compile firmware
         run: pio run --environment ulanzi
 
+      - name: Build LittleFS image (SPA)
+        run: pio run --environment ulanzi --target buildfs
+
       - name: Update web flasher
         run: |
           cp .pio/build/ulanzi/firmware.bin docs/public/ulanzi_flasher/firmware/firmware.bin
           cp .pio/build/ulanzi/bootloader.bin docs/public/ulanzi_flasher/firmware/bootloader.bin
           cp .pio/build/ulanzi/partitions.bin docs/public/ulanzi_flasher/firmware/partitions.bin
+          cp .pio/build/ulanzi/littlefs.bin docs/public/ulanzi_flasher/firmware/littlefs.bin
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin docs/public/ulanzi_flasher/firmware/boot_app0.bin
           jq '.version = "${{ steps.version.outputs.version }}"' \
             docs/public/ulanzi_flasher/firmware/manifest.json > manifest.tmp \
@@ -80,7 +84,9 @@ jobs:
         with:
           name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
-          files: .pio/build/ulanzi/firmware.bin
+          files: |
+            .pio/build/ulanzi/firmware.bin
+            .pio/build/ulanzi/littlefs.bin
 
   deploy-docs:
     name: Deploy documentation


### PR DESCRIPTION
## Summary

- Build the LittleFS image during the Release workflow (`pio run -t buildfs`) and ship it both in the web flasher bundle and as a GitHub Release asset.

## Why

The release workflow only built and copied `firmware.bin` / `bootloader.bin` / `partitions.bin` / `boot_app0.bin` — never `littlefs.bin`. As a result, after `v0.3.0` the web flasher served a fresh firmware image but reused the LittleFS image from `v0.2.0`, so the SPA on the device never updated. New UI (e.g. night-mode settings from #45) was not reachable on fresh installs.

## Changes

- New step `Build LittleFS image (SPA)` after firmware compile.
- `Update web flasher` step copies `littlefs.bin` next to the other binaries.
- GitHub Release assets now include `littlefs.bin` alongside `firmware.bin`.

## Test plan

- [ ] Tag `v0.3.1` after merge — verify the workflow run produces `littlefs.bin` and that:
  - [ ] `docs/public/ulanzi_flasher/firmware/littlefs.bin` is updated by the auto-commit
  - [ ] `manifest.json` version bumps to 0.3.1
  - [ ] GitHub Release contains both `firmware.bin` and `littlefs.bin`
- [ ] Re-flash a device via the web flasher and confirm Settings → Night Mode is visible.

## Notes

- OTA via `UpdateManager` still updates only the app partition. Existing OTA users will need a full flash (or a follow-up to extend `UpdateManager` with FS update support) to pick up SPA changes.

Refs: #45