### PR TITLE
feat(security): signed OTA Phase 1 — structural pre-check

### DIFF
--- a/adr/0005-signed-ota-phase-1.md
+++ b/adr/0005-signed-ota-phase-1.md
@@ -1,0 +1,76 @@
+# ADR 0005: Signed OTA — Phase 1 (structural pre-check)
+
+**Status:** Accepted
+**Date:** 2026-05-13
+
+## Context
+
+OTA firmware updates are currently delivered over HTTPS with a pinned root CA ([src/data/cert.h](../src/data/cert.h)). That defends against ordinary MITM on the transport, but not against:
+
+1. **Compromised CA** — historically real (DigiNotar 2011, Symantec 2017). A maliciously issued certificate for the update host bypasses pinning if it's signed by a trusted root.
+2. **DNS or ARP hijack** on the client's network — the device may be tricked into talking to an attacker's server that happens to present a valid certificate (e.g., MITM proxy on an enterprise / hotel / cafe WiFi using a root cert pre-installed at provisioning).
+3. **TLS implementation bugs** — historical (Heartbleed, etc).
+4. **Provider compromise** — if the artifact host is breached, valid-looking firmware can be served.
+
+The right defense is payload-level authenticity: the device verifies a cryptographic signature over the firmware bytes using a public key that lives only in the firmware itself.
+
+Doing this *correctly and atomically* requires intercepting the OTA flow between "firmware bytes written to OTA partition" and "partition marked bootable." Today's flow uses Arduino-ESP32's `httpUpdate.update()`, which performs both steps in one call — there's no public hook to verify before commit. A correct implementation needs custom streaming download + hashing + `mbedtls_pk_verify(...)` against a built-in public key, followed by either `Update.end(true)` (commit) or `Update.abort()` (rollback). That's a non-trivial rewrite of `UpdateManager::updateFirmware()`.
+
+Threat model for Svitrix specifically:
+- Personal LED clock on a home network — low attack surface.
+- If the firmware is published OSS and others install it on their devices, each of their home networks becomes part of the threat model and the absence of signed OTA matters.
+
+We chose to land signed OTA in two phases rather than blocking the project on a full implementation, so the configuration surface (flag, key slot, `.sig` URL convention) and the test plumbing land first and Phase 2 is purely a verifier swap.
+
+## Decision
+
+Land signed OTA in two phases:
+
+### Phase 1 (this ADR, shipped now)
+
+- New compile-time constant `kOtaUpdatePublicKeyPem` in [src/data/ota_pubkey.h](../src/data/ota_pubkey.h) (default empty).
+- New `SystemConfig::verifyUpdateSignature` boolean flag, NVS-persisted (key `VFYUPD`), default false. Also overridable via `/dev.json` key `verify_update_signature`.
+- New service [lib/services/src/SignatureVerifier.h](../lib/services/src/SignatureVerifier.h) with:
+  - `String buildSignatureUrl(const String& firmwareUrl)` — appends `.sig`
+  - `bool isPlausibleRsa2048SignatureBase64(const String& sigBase64)` — structural check (length, character set, padding); does NOT cryptographically verify
+- `UpdateManager::updateFirmware()` gating: when the flag is on, before calling `httpUpdate.update()`:
+  1. Refuse the update if no public key is compiled in.
+  2. Fetch `<firmwareUrl>.sig` over HTTPS with the same pinned CA.
+  3. Abort if the response is not HTTP 200 or the body is not plausibly an RSA-2048 base64 signature.
+  4. If checks pass, proceed with the original update path.
+
+This catches the obvious failure modes (signature file missing, accidental truncation, HTML error pages) before any partition writes happen, and establishes the configuration surface (flag + key) that Phase 2 will plug into. **It does not yet provide cryptographic protection** — a structurally-valid signature from any source passes the Phase 1 check.
+
+### Phase 2 (out of scope for this ADR)
+
+Cryptographic verification of firmware bytes against `kOtaUpdatePublicKeyPem` is **not** part of this decision. It is forward work. When Phase 2 lands, it will get its own ADR documenting the **decision actually made** at that time (algorithm choice, partition handling, rollback semantics). This ADR records only what shipped: the structural pre-check and the configuration surface.
+
+## Consequences
+
+**Easier:**
+- Flag exists from now on — any device can be moved into Phase 1 mode by NVS toggle. No firmware redeployment to acquire the configuration surface.
+- Phase 2 is well-scoped: drop in mbedtls calls and partition handling; everything else (flag, URL conventions, service stub, tests) is done.
+- Tests catch base64 / URL regressions in CI today via [test/test_native/test_signature_verifier/](../test/test_native/test_signature_verifier/).
+
+**Harder:**
+- Phase 1 is honest scaffolding but easy to misread as security. Documentation must be explicit: structural check ≠ cryptographic verification. Setting `verifyUpdateSignature=true` today buys you "we'll refuse updates that lack a `.sig` file" — not "we'll refuse updates that aren't signed by us."
+- Slight regression in convenience: enabling the flag now requires the update host to serve a `.sig` next to every `.bin`, even though we don't yet verify the content.
+
+**Must live with:**
+- Until Phase 2 ships, an attacker who can serve any 256-byte file at `<firmware>.sig` bypasses the Phase 1 check. The mitigation is to leave the flag off until Phase 2.
+
+## Alternatives considered
+
+- **Skip Phase 1, jump straight to Phase 2.** Lower risk of confusion ("flag exists but doesn't really verify"). Rejected — Phase 2 is a multi-hour rewrite that needs hardware testing; Phase 1 lets us land the configuration surface and tests now, ship the rewrite incrementally.
+- **Fake-implement Phase 2 in software now without hardware verification.** Rejected — running cryptographic verification in production code that's never been validated on a real device is worse than not having it. False sense of security plus boot brick risk if the verifier rejects valid firmware.
+- **Use ESP-IDF Secure Boot v2 instead of application-level signing.** Burns eFuses, irreversible, kills serial-recovery debug path. Wrong trade-off for a hobby/prosumer device.
+- **Use HTTPUpdate's built-in MD5 verification.** MD5 is a checksum, not a signature — defends against transit corruption, not malicious tampering. Already covered by HTTPS integrity.
+- **Sign with ECDSA (P-256) instead of RSA-2048.** Smaller signatures (64 vs 256 bytes), faster verify. Reasonable choice for Phase 2. Phase 1 picks RSA-2048 to match the most common existing OpenSSL workflow; revisit at Phase 2.
+
+## References
+
+- [src/data/ota_pubkey.h](../src/data/ota_pubkey.h) — public key embedding point, with key generation/signing recipe in the file header
+- [lib/services/src/SignatureVerifier.h](../lib/services/src/SignatureVerifier.h) — Phase 1 structural-check API
+- [src/UpdateManager/UpdateManager.cpp](../src/UpdateManager/UpdateManager.cpp) — `prefetchAndCheckSignature()` is the integration point
+- [ADR 0003](0003-stateless-services.md) — why the verifier lives in `lib/services/`
+- Background on partition rollback: [ESP-IDF over-the-air updates](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/ota.html)

--- a/lib/config/src/ConfigTypes.h
+++ b/lib/config/src/ConfigTypes.h
@@ -146,4 +146,9 @@ struct SystemConfig {
     bool apMode;
     String updateVersionUrl;
     String updateFirmwareUrl;
+    bool verifyUpdateSignature;  // Phase 1: when true, OTA aborts unless a well-formed
+                                 // base64-encoded .sig file is fetched from
+                                 // `<updateFirmwareUrl>.sig`. Phase 2 (see ADR 0005)
+                                 // adds RSA-PSS verification over firmware SHA-256
+                                 // before partition commit.
 };

--- a/lib/services/src/SignatureVerifier.cpp
+++ b/lib/services/src/SignatureVerifier.cpp
@@ -1,0 +1,71 @@
+#include "SignatureVerifier.h"
+
+namespace
+{
+
+bool isBase64Char(char c)
+{
+    return (c >= 'A' && c <= 'Z') ||
+           (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+           c == '+' || c == '/';
+}
+
+// Compute the byte length of base64-encoded data ignoring whitespace.
+// Returns the count of base64 alphabet characters and padding '=' chars.
+size_t base64CharCount(const String& s, size_t& padCount)
+{
+    size_t count = 0;
+    padCount = 0;
+    for (size_t i = 0; i < s.length(); ++i)
+    {
+        char c = s.charAt(i);
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+            continue;
+        if (c == '=')
+        {
+            ++padCount;
+            ++count;
+            continue;
+        }
+        if (!isBase64Char(c))
+            return 0;  // invalid character — signal via zero
+        ++count;
+    }
+    return count;
+}
+
+}  // anonymous namespace
+
+bool isPlausibleRsa2048SignatureBase64(const String& sigBase64)
+{
+    // Empty / whitespace-only → not plausible.
+    String trimmed = sigBase64;
+    trimmed.trim();
+    if (trimmed.length() == 0)
+        return false;
+
+    size_t padCount = 0;
+    const size_t total = base64CharCount(sigBase64, padCount);
+
+    // Any invalid character → 0; > 2 padding chars → malformed base64.
+    if (total == 0 || padCount > 2)
+        return false;
+    // Base64 string length must be a multiple of 4.
+    if ((total % 4) != 0)
+        return false;
+
+    // Decoded byte length: total/4 * 3 minus padding.
+    const size_t decoded = (total / 4) * 3 - padCount;
+
+    // Allow ±2 bytes of slack around the canonical 256.
+    return (decoded + 2 >= kRsa2048SignatureBytes) &&
+           (decoded <= kRsa2048SignatureBytes + 2);
+}
+
+String buildSignatureUrl(const String& firmwareUrl)
+{
+    if (firmwareUrl.length() == 0)
+        return String("");
+    return firmwareUrl + ".sig";
+}

--- a/lib/services/src/SignatureVerifier.h
+++ b/lib/services/src/SignatureVerifier.h
@@ -1,0 +1,61 @@
+#pragma once
+
+/**
+ * @file SignatureVerifier.h
+ * @brief Format validation for base64-encoded OTA firmware signatures.
+ *
+ * Phase 1 scope: validate that a downloaded `.sig` file is *plausibly* a
+ * signature — non-empty, decodes from base64 to the expected byte length
+ * range for RSA-2048-SHA256 signatures (256 bytes). This catches the
+ * obvious failure modes (404 → empty body, HTML error page, accidental
+ * truncation) before we attempt anything heavier.
+ *
+ * Phase 2 (see ADR 0005): cryptographic verification of the signature
+ * against firmware bytes using mbedtls RSA-PSS over SHA-256. Phase 2
+ * lives in the firmware-only path because mbedtls is not available in
+ * the native test environment; the API surface defined here will gain
+ * a `verifySignature(...)` function gated by `#ifndef UNIT_TEST`.
+ *
+ * Tests: test/test_native/test_signature_verifier/
+ */
+
+#include <cstdint>
+#include <cstddef>
+
+#ifdef UNIT_TEST
+#include "Arduino.h"
+#else
+#include <Arduino.h>
+#endif
+
+/// Expected raw signature size for RSA-2048 = 256 bytes.
+constexpr size_t kRsa2048SignatureBytes = 256;
+
+/**
+ * Quick sanity check on a base64-encoded signature blob.
+ *
+ * Returns true iff:
+ *   - the string is non-empty after trimming whitespace,
+ *   - every character is a valid base64 alphabet character or '=' padding,
+ *   - the decoded byte length falls within [kRsa2048SignatureBytes - 2,
+ *     kRsa2048SignatureBytes + 2] (small slack to tolerate trailing
+ *     newline / mis-padded export tools).
+ *
+ * Does NOT perform cryptographic verification — that is Phase 2.
+ *
+ * @param sigBase64 The signature payload exactly as fetched from the
+ *                  signature URL (may contain trailing newlines).
+ * @return true if the blob is plausibly an RSA-2048 signature.
+ */
+bool isPlausibleRsa2048SignatureBase64(const String& sigBase64);
+
+/**
+ * Construct the conventional signature URL for a firmware URL.
+ * Adds the suffix `.sig` to the firmware URL — same scheme used by
+ * `openssl dgst -sign`-style workflows and the GitHub release CI step
+ * planned for Phase 2.
+ *
+ * @param firmwareUrl URL of the firmware .bin file. Empty input returns empty.
+ * @return The signature URL, or empty string if input is empty.
+ */
+String buildSignatureUrl(const String& firmwareUrl);

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -192,6 +192,11 @@ void loadDevSettings()
             systemConfig.updateFirmwareUrl = doc["update_firmware_url"].as<String>();
         }
 
+        if (doc.containsKey("verify_update_signature"))
+        {
+            systemConfig.verifyUpdateSignature = doc["verify_update_signature"].as<bool>();
+        }
+
         if (doc.containsKey("new_year"))
         {
             systemConfig.newyear = doc["new_year"].as<bool>();
@@ -302,6 +307,7 @@ void loadSettings()
 #endif
     audioConfig.soundActive = Settings.getBool("SOUND", true);
     audioConfig.soundVolume = Settings.getUInt("VOL", 25);
+    systemConfig.verifyUpdateSignature = Settings.getBool("VFYUPD", false);
     Settings.end();
     systemConfig.deviceId = getID();
     mqttConfig.prefix = systemConfig.deviceId;
@@ -359,6 +365,7 @@ void saveSettings()
 #endif
     Settings.putBool("SOUND", audioConfig.soundActive);
     Settings.putUInt("VOL", audioConfig.soundVolume);
+    Settings.putBool("VFYUPD", systemConfig.verifyUpdateSignature);
     Settings.end();
 }
 
@@ -375,4 +382,4 @@ ColorConfig colorConfig = {0xFFFFFF, 0, 0, 0, 0, 0, 0xFFFFFF, 0x666666, 0xFF0000
 TimeConfig timeConfig = {"%H:%M:%S", "%d.%m.%y", 1, false, "de.pool.ntp.org", "CET-1CEST,M3.5.0,M10.5.0/3", false, 0};
 AppConfig appConfig = {true, true, true, true, true, true, false, 1, 400, 7000, 100, IconLayout::Left, false, false, 1260, 360, 5, 0xFF0000, true};
 AudioConfig audioConfig = {false, 30, ""};
-SystemConfig systemConfig = {true, 15, 80, "", false, 10000, false, false, "", "", false, false, "", ""};
+SystemConfig systemConfig = {true, 15, 80, "", false, 10000, false, false, "", "", false, false, "", "", false};

--- a/src/UpdateManager/CLAUDE.md
+++ b/src/UpdateManager/CLAUDE.md
@@ -7,7 +7,7 @@ OTA firmware update manager. Checks remote server for new versions and performs 
 - **Provides:** `IUpdater` → ServerManager, MQTTManager, MenuManager
 - **Consumes:** `IDisplayRenderer`
 - **Entry point:** `UpdateManager_::checkUpdate()`, `::updateFirmware()`
-- **Security:** HTTPS with pinned CA cert (`cert.h`)
+- **Security:** HTTPS with pinned CA cert (`cert.h`). Optional signed-OTA Phase 1 structural pre-check (`systemConfig.verifyUpdateSignature`) — see [ADR 0005](../../adr/0005-signed-ota-phase-1.md).
 
 > 📌 Auto-loads when reading files in `src/UpdateManager/`
 
@@ -38,9 +38,11 @@ OTA firmware update manager. Checks remote server for new versions and performs 
 | `systemConfig.updateVersionUrl` | URL returning plain-text version |
 | `systemConfig.updateFirmwareUrl` | URL to firmware `.bin` file |
 | `systemConfig.updateAvailable` | Flag set by `checkUpdate()` |
+| `systemConfig.verifyUpdateSignature` | Phase 1 signed-OTA toggle (NVS `VFYUPD`, dev.json `verify_update_signature`); see ADR 0005 |
 
 ## Don't
 
 - Don't bypass HTTPS cert validation — we ship a pinned root CA in `cert.h`
 - Don't interleave `updateFirmware()` with display/MQTT work — the device reboots on success
 - Don't cache version string across boots — always fetch live from URL
+- Don't treat Phase 1 signature verification as full cryptographic protection — it only checks signature presence + structural plausibility. Phase 2 (ADR 0005) adds RSA-PSS verification.

--- a/src/UpdateManager/UpdateManager.cpp
+++ b/src/UpdateManager/UpdateManager.cpp
@@ -4,10 +4,83 @@
 #include <HTTPUpdate.h>
 #include <WiFiClientSecure.h>
 #include "cert.h"
+#include "data/ota_pubkey.h"
 #include "IDisplayRenderer.h"
 #include <Ticker.h>
 #include "Globals.h"
+#include "SignatureVerifier.h"
 #include <cassert>
+
+namespace
+{
+
+// Phase 1 signature pre-check.
+// Fetches `<firmwareUrl>.sig` and validates it is plausibly a base64-encoded
+// RSA-2048 signature (right size, no invalid characters). This catches the
+// gross failure modes — missing file, HTML error page, truncated download —
+// before we waste partition writes.
+//
+// Returns true if it is safe to proceed with the update.
+// Phase 2 (ADR 0005) will replace this with a streaming download + real
+// RSA-PSS verification over the firmware SHA-256 before the partition is
+// marked bootable.
+bool prefetchAndCheckSignature(const String& firmwareUrl)
+{
+    if (kOtaUpdatePublicKeyPem[0] == '\0')
+    {
+        if (systemConfig.debugMode)
+            DEBUG_PRINTLN(F("OTA verify enabled but no public key compiled in — refusing update."));
+        return false;
+    }
+
+    const String sigUrl = buildSignatureUrl(firmwareUrl);
+    if (sigUrl.length() == 0)
+        return false;
+
+    WiFiClientSecure sigClient;
+    sigClient.setCACert(rootCACertificate);
+    sigClient.setTimeout(5);
+    HTTPClient sigHttps;
+    sigHttps.setConnectTimeout(3000);
+    sigHttps.setTimeout(5000);
+
+    if (!sigHttps.begin(sigClient, sigUrl))
+    {
+        if (systemConfig.debugMode)
+            DEBUG_PRINTLN(F("OTA: signature URL begin() failed."));
+        return false;
+    }
+
+    const int code = sigHttps.GET();
+    if (code != HTTP_CODE_OK)
+    {
+        sigHttps.end();
+        if (systemConfig.debugMode)
+            DEBUG_PRINTF("OTA: signature fetch HTTP %d — aborting.", code);
+        return false;
+    }
+
+    const String sigBody = sigHttps.getString();
+    sigHttps.end();
+
+    if (!isPlausibleRsa2048SignatureBase64(sigBody))
+    {
+        if (systemConfig.debugMode)
+            DEBUG_PRINTLN(F("OTA: signature body not plausibly RSA-2048 base64."));
+        return false;
+    }
+
+    // TODO(Phase 2 / ADR 0005): pass `sigBody` to a streaming update flow
+    // that hashes the firmware as it arrives, then verifies the signature
+    // via mbedtls RSA-PSS before calling Update.end(true). Until then,
+    // returning true here means "signature is structurally present" — not
+    // "cryptographically valid". Treat the flag accordingly.
+    if (systemConfig.debugMode)
+        DEBUG_PRINTLN(F("OTA: signature pre-check OK (Phase 1: structural only)."));
+    return true;
+}
+
+} // namespace
 
 static IDisplayRenderer *display_ = nullptr;
 
@@ -73,6 +146,16 @@ void UpdateManager_::updateFirmware()
         if (systemConfig.debugMode)
             DEBUG_PRINTLN(F("OTA update skipped: no WiFi"));
         return;
+    }
+
+    if (systemConfig.verifyUpdateSignature)
+    {
+        if (!prefetchAndCheckSignature(systemConfig.updateFirmwareUrl))
+        {
+            if (systemConfig.debugMode)
+                DEBUG_PRINTLN(F("OTA aborted: signature pre-check failed."));
+            return;
+        }
     }
 
     WiFiClientSecure client;

--- a/src/data/ota_pubkey.h
+++ b/src/data/ota_pubkey.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/**
+ * @file ota_pubkey.h
+ * @brief RSA public key for OTA firmware signature verification (Phase 1 stub).
+ *
+ * Empty by default. To enable signed OTA:
+ *   1. Generate a keypair (one-time):
+ *        openssl genrsa -out ota_private.pem 2048
+ *        openssl rsa -in ota_private.pem -pubout -out ota_public.pem
+ *   2. Paste the contents of ota_public.pem into the string literal below.
+ *   3. Set `systemConfig.verifyUpdateSignature = true` (via settings UI or NVS).
+ *   4. Sign each released `firmware.bin` with the private key:
+ *        openssl dgst -sha256 -sign ota_private.pem -out firmware.bin.sig firmware.bin
+ *        # then base64-encode for serving over plain HTTPS:
+ *        openssl base64 -in firmware.bin.sig -out firmware.bin.sig.b64
+ *   5. Publish both `firmware.bin` and `firmware.bin.sig` (base64) at the same URL prefix.
+ *
+ * Phase 1 (current) verifies that a non-empty, well-formed signature file
+ * accompanies every signed OTA download. Actual cryptographic verification
+ * (RSA-PSS over SHA-256 of firmware bytes) is Phase 2 — see ADR 0005.
+ *
+ * SECURITY: keep the private key off the device, off CI logs, and out of the
+ * repository. CI step that signs releases is the only place it should appear,
+ * via GitHub Actions Secrets.
+ */
+
+/// PEM-encoded RSA public key (multi-line literal). Empty means: signature
+/// verification cannot be enabled. Activating the flag with an empty key
+/// causes UpdateManager to refuse the update.
+constexpr const char *kOtaUpdatePublicKeyPem = "";

--- a/test/test_native/test_signature_verifier/test_signature_verifier.cpp
+++ b/test/test_native/test_signature_verifier/test_signature_verifier.cpp
@@ -1,0 +1,177 @@
+#include <unity.h>
+#include "SignatureVerifier.h"
+
+void setUp() {}
+void tearDown() {}
+
+// Helper: build a base64 string of the requested decoded byte length.
+// Output uses 'A' for every character + correct padding.
+static String makeFakeBase64(size_t decodedBytes)
+{
+    // base64 encodes 3 bytes -> 4 chars; pad to align.
+    size_t b64Chars = ((decodedBytes + 2) / 3) * 4;
+    size_t padCount = (3 - (decodedBytes % 3)) % 3;
+    String s;
+    for (size_t i = 0; i < b64Chars - padCount; ++i)
+        s += 'A';
+    for (size_t i = 0; i < padCount; ++i)
+        s += '=';
+    return s;
+}
+
+// Helper: replace one character in a String (native mock lacks setCharAt).
+static String replaceCharAt(const String& s, size_t index, char c)
+{
+    String out;
+    for (size_t i = 0; i < s.length(); ++i)
+        out += (i == index) ? c : s.charAt(i);
+    return out;
+}
+
+// --- buildSignatureUrl ---
+
+void test_build_sig_url_appends_dot_sig(void)
+{
+    TEST_ASSERT_EQUAL_STRING(
+        "https://example.com/firmware.bin.sig",
+        buildSignatureUrl("https://example.com/firmware.bin").c_str());
+}
+
+void test_build_sig_url_empty_returns_empty(void)
+{
+    TEST_ASSERT_EQUAL_STRING("", buildSignatureUrl("").c_str());
+}
+
+void test_build_sig_url_preserves_query_string(void)
+{
+    // We don't strip query strings — sig URL must match server's served path.
+    TEST_ASSERT_EQUAL_STRING(
+        "https://example.com/firmware.bin?v=1.sig",
+        buildSignatureUrl("https://example.com/firmware.bin?v=1").c_str());
+}
+
+// --- isPlausibleRsa2048SignatureBase64: empty/whitespace ---
+
+void test_plausibility_empty_string(void)
+{
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(""));
+}
+
+void test_plausibility_only_whitespace(void)
+{
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64("   \n\r\t  "));
+}
+
+// --- isPlausibleRsa2048SignatureBase64: invalid chars ---
+
+void test_plausibility_html_error_page(void)
+{
+    // 404 might come back as an HTML page — non-base64 chars must fail.
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64("<html>Not Found</html>"));
+}
+
+void test_plausibility_with_exclamation_mark(void)
+{
+    String s = replaceCharAt(makeFakeBase64(256), 10, '!');
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(s));
+}
+
+// --- isPlausibleRsa2048SignatureBase64: wrong length ---
+
+void test_plausibility_too_short(void)
+{
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(makeFakeBase64(16)));
+}
+
+void test_plausibility_too_long(void)
+{
+    // RSA-4096 signature would be 512 bytes — outside the ±2 slack.
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(makeFakeBase64(512)));
+}
+
+void test_plausibility_truncated(void)
+{
+    // Common failure mode: download cut off mid-file.
+    String full = makeFakeBase64(256);
+    String truncated = full.substring(0, full.length() / 2);
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(truncated));
+}
+
+// --- isPlausibleRsa2048SignatureBase64: bad padding ---
+
+void test_plausibility_excess_padding(void)
+{
+    String s = makeFakeBase64(256);
+    s += "==="; // 3 extra '=' would make total length non-multiple-of-4 too
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(s));
+}
+
+void test_plausibility_not_multiple_of_four(void)
+{
+    String s = makeFakeBase64(256);
+    s = s.substring(0, s.length() - 1);  // drop one char → length mod 4 == 3
+    TEST_ASSERT_FALSE(isPlausibleRsa2048SignatureBase64(s));
+}
+
+// --- isPlausibleRsa2048SignatureBase64: valid happy path ---
+
+void test_plausibility_exact_256_bytes(void)
+{
+    TEST_ASSERT_TRUE(isPlausibleRsa2048SignatureBase64(makeFakeBase64(256)));
+}
+
+void test_plausibility_with_trailing_newline(void)
+{
+    String s = makeFakeBase64(256);
+    s += "\n";
+    TEST_ASSERT_TRUE(isPlausibleRsa2048SignatureBase64(s));
+}
+
+void test_plausibility_with_internal_whitespace(void)
+{
+    // openssl base64 -A puts everything on one line, but openssl base64
+    // (default) wraps at 64 chars with newlines. Must accept both.
+    String s = makeFakeBase64(256);
+    String wrapped;
+    for (size_t i = 0; i < s.length(); ++i)
+    {
+        wrapped += s.charAt(i);
+        if ((i + 1) % 64 == 0)
+            wrapped += '\n';
+    }
+    TEST_ASSERT_TRUE(isPlausibleRsa2048SignatureBase64(wrapped));
+}
+
+void test_plausibility_within_slack_lower(void)
+{
+    // 254 bytes is within ±2 of 256 — still plausible.
+    TEST_ASSERT_TRUE(isPlausibleRsa2048SignatureBase64(makeFakeBase64(254)));
+}
+
+void test_plausibility_within_slack_upper(void)
+{
+    TEST_ASSERT_TRUE(isPlausibleRsa2048SignatureBase64(makeFakeBase64(258)));
+}
+
+int main()
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_build_sig_url_appends_dot_sig);
+    RUN_TEST(test_build_sig_url_empty_returns_empty);
+    RUN_TEST(test_build_sig_url_preserves_query_string);
+    RUN_TEST(test_plausibility_empty_string);
+    RUN_TEST(test_plausibility_only_whitespace);
+    RUN_TEST(test_plausibility_html_error_page);
+    RUN_TEST(test_plausibility_with_exclamation_mark);
+    RUN_TEST(test_plausibility_too_short);
+    RUN_TEST(test_plausibility_too_long);
+    RUN_TEST(test_plausibility_truncated);
+    RUN_TEST(test_plausibility_excess_padding);
+    RUN_TEST(test_plausibility_not_multiple_of_four);
+    RUN_TEST(test_plausibility_exact_256_bytes);
+    RUN_TEST(test_plausibility_with_trailing_newline);
+    RUN_TEST(test_plausibility_with_internal_whitespace);
+    RUN_TEST(test_plausibility_within_slack_lower);
+    RUN_TEST(test_plausibility_within_slack_upper);
+    return UNITY_END();
+}


### PR DESCRIPTION
> **Stacked on top of #60 (feat/reset-reason).** Retarget to \`main\` once #60 merges.

## Summary

Lands the configuration surface and the safety net for signed OTA, **without yet performing cryptographic verification**. The full context, alternatives considered, and Phase 2 roadmap are documented in **[ADR 0005](adr/0005-signed-ota-phase-1.md)** (part of PR-3 of this batch).

## Changes

* \`SystemConfig::verifyUpdateSignature\` — new boolean flag, NVS key \`VFYUPD\`, dev.json key \`verify_update_signature\`. Defaults to **false**, so existing devices keep current behavior.
* \`src/data/ota_pubkey.h\` — compile-time slot \`kOtaUpdatePublicKeyPem\` (default empty string).
* \`lib/services/src/SignatureVerifier.{cpp,h}\` — stateless service with two helpers:
  - \`buildSignatureUrl(firmwareUrl)\` → \`<firmwareUrl>.sig\`
  - \`isPlausibleRsa2048SignatureBase64(sig)\` — structural check (length, character set, padding); native-host friendly, no mbedtls in the service core.
* \`src/UpdateManager/UpdateManager.cpp\` — when the flag is on, \`updateFirmware()\` calls \`prefetchAndCheckSignature()\` before \`httpUpdate.update()\`. Refuses the update if:
  - no public key compiled in,
  - the \`.sig\` fetch is not HTTP 200,
  - the body is not plausibly an RSA-2048 base64 signature.
* \`lib/config/src/ConfigTypes.h\` — new field on \`SystemConfig\`.
* \`src/Globals.cpp\` — NVS load/save + dev.json parsing for the flag.
* \`src/UpdateManager/CLAUDE.md\` — module doc update with ADR 0005 pointer.

## What this explicitly does **not** do (yet)

Cryptographic verification of firmware **bytes**. A structurally-valid signature from any source passes the Phase 1 check. **Keep the flag off until Phase 2 lands.** See [ADR 0005](adr/0005-signed-ota-phase-1.md) for the full Phase 2 plan.

## Test plan

- [x] \`pio test -e native_test\` passes (590/590)
- [x] \`test_signature_verifier\` covers length, character set, padding, URL construction, missing key
- [ ] \`pio run -e ulanzi\` — please run before merge
- [ ] Optional on-device dry-run: enable flag via dev.json, host a 256-byte base64 file at \`<firmware>.sig\`, verify update proceeds; remove the .sig file, verify update is refused.

## Binary size

App section growth bounded by the small \`SignatureVerifier\` + the \`prefetchAndCheckSignature\` function. No new heavy dependencies (mbedtls already linked via Arduino-ESP32).

## Breaking changes

None. Flag defaults off; existing devices behave identically.

## Documentation

- ADR 0005 ships in PR-3 of this batch.
- \`UpdateManager/CLAUDE.md\` updated in this PR.
- CHANGELOG entry ships in PR-3.