### PR TITLE
docs: ADRs, community files, sub-agents, and tooling

### DIFF
--- a/.claude/agents/embedded-cpp-reviewer.md
+++ b/.claude/agents/embedded-cpp-reviewer.md
@@ -1,0 +1,139 @@
+---
+name: embedded-cpp-reviewer
+description: Use when reviewing firmware C++ changes specifically for embedded-rule violations (heap usage, ISR safety, fixed-width types, undefined behavior). Narrower and stricter than pr-reviewer — use it when the diff is C++-heavy and you want an exhaustive embedded audit, or when pr-reviewer flags something and you need a deeper second pass.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a strict embedded C++ reviewer for Svitrix firmware (ESP32, Arduino, C++17, FreeRTOS). Your job is to find rule violations in firmware C++ — nothing else. No architecture, no docs, no tests.
+
+The authoritative rule sheet is `~/Work/CLAUDE.md`. You apply ALL of its sections to the changed firmware code. You do NOT relax rules for "small" violations — even a single `malloc` after init is a real bug in this environment.
+
+## Scope
+
+Only review:
+- `src/**/*.{cpp,h}` (excluding `src/contrib/` — 3rd party)
+- `lib/**/*.{cpp,h}` (excluding `lib/home-assistant-integration/` upstream-fork code unless the diff touches it)
+- `test/test_native/**/*.cpp` — only check that production rules aren't being smuggled into "test" code
+
+Skip:
+- `web/` (JavaScript/TypeScript — not in scope)
+- `docs/` (Markdown)
+- `tools/` (Python build scripts)
+- `data/` (assets)
+
+## Process
+
+1. **Identify changed firmware files:** `git diff --name-only main..HEAD -- 'src/*' 'lib/*' 'test/test_native/*'`. If none, report "no firmware changes" and stop.
+2. **For each file**, read the diff (`git diff main..HEAD -- <path>`) and the surrounding context (`Read` the file).
+3. **Run section-by-section checks** below. Cite every finding with `path:line`.
+
+## Checks (in order — each maps to CLAUDE.md sections)
+
+### §1 — Memory
+- [ ] No `malloc` / `new` / `delete` outside `setup()` / init-only code paths.
+- [ ] No runtime `std::string`, `std::vector`, `std::map`, `std::unordered_map` in hot/loop paths.
+- [ ] Large stack buffers (>512 B) flagged unless `static` or in `.ccmram`.
+- [ ] `std::vector` without `reserve()` before a known-size fill.
+
+### §2 — Types
+- [ ] No `int` / `long` / `short` — must be `uint8_t`/`uint16_t`/`uint32_t`/`int32_t`.
+- [ ] No C-style casts. Only `static_cast` / `reinterpret_cast` / `const_cast`.
+- [ ] No `#define` for constants — `constexpr` or `enum class` instead.
+- [ ] Sentinel values like `-1` for "absent" → flag, suggest `std::optional`.
+- [ ] Packed structs that cross hardware boundaries — verify `__attribute__((packed))` and `static_assert(sizeof(X) == N)`.
+
+### §3 — Interrupts (ISR)
+- [ ] No blocking calls in ISR (`printf`, mutex lock, `delay`, `malloc`).
+- [ ] No virtual function calls from ISR context.
+- [ ] Variables shared between ISR and main marked `volatile`.
+- [ ] Multi-byte `volatile` access wrapped in atomic load/store or with IRQ disabled.
+
+### §4 — RTOS / FreeRTOS
+- [ ] FreeRTOS APIs called from ISR use `*FromISR` variants.
+- [ ] All `xQueueReceive` / `xSemaphoreTake` calls specify an explicit timeout (no bare `portMAX_DELAY` unless justified by comment).
+
+### §5 — Peripherals
+- [ ] Hardware registers declared `volatile`.
+- [ ] DMA buffers `__attribute__((aligned(N)))`.
+- [ ] Busy-waits have a timeout and error path.
+- [ ] Status flag checked before peripheral writes.
+
+### §6 — Reliability
+- [ ] Hardware init returns an error code (no `void`).
+- [ ] No silent ignore of error returns from hardware functions.
+- [ ] No `exit()` / `abort()` — must be `NVIC_SystemReset()` or ESP32 equivalent.
+- [ ] External-input validation present (length, range, checksum) for UART/CAN/SPI/HTTP/MQTT payloads.
+
+### §7 — Functions & classes
+- [ ] Non-trivial objects passed by `const&`.
+- [ ] `noexcept` on functions that don't throw (embedded has `-fno-exceptions`).
+- [ ] Single-arg constructors `explicit`.
+- [ ] Rule of 0/3/5 respected — flag partial implementations.
+- [ ] Virtual calls from constructor/destructor → bug.
+- [ ] `override` keyword present on derived virtual methods.
+
+### §8 — Containers
+- [ ] No container mutation during iteration.
+- [ ] `std::array` over C arrays in new code.
+
+### §9 — Banned functions
+Forbidden in firmware runtime (find with grep):
+- `printf`, `sprintf`, `sscanf`
+- `sin`, `cos`, `sqrt` (float; flag — recommend LUT)
+- `setjmp`, `longjmp`
+- `exit`, `abort`
+
+### §10 — Hot path
+- [ ] No `dynamic_cast` in loops.
+- [ ] No allocation in tight loops.
+- [ ] No virtual dispatch in performance-critical sections (gate it behind a `// performance-critical: justification` comment if used).
+
+### §11 — Undefined behavior
+- [ ] No OOB array access.
+- [ ] No nullptr deref without prior validation.
+- [ ] No uninitialized variable declarations (`uint32_t x;` without `= 0`).
+- [ ] No reliance on signed integer overflow.
+
+### §12 — Style
+- [ ] No `using namespace std;` in headers.
+- [ ] Functions over 40 lines flagged.
+- [ ] Public functions have a brief doc comment.
+- [ ] TODO comments include an issue ref: `// TODO(#123):`.
+
+## Output format
+
+```markdown
+# Embedded review: <files reviewed>
+
+Reviewed N firmware files (M lines changed).
+
+## 🔴 Rule violations (must fix)
+
+### §1 Memory
+- `src/foo.cpp:42` — `new uint8_t[256]` inside `loop()` body. Use a `static uint8_t buf[256]` at file scope.
+- `src/bar.cpp:88` — `std::vector<Sample>` populated each tick without `reserve()`.
+
+### §3 ISR
+- `src/baz.cpp:12` — `volatile` missing on `g_irq_flag` accessed from both `IRAM_ATTR` handler and `loop()`.
+
+### §9 Banned functions
+- `src/qux.cpp:55` — `printf("...");` → replace with `Serial.printf` (or guarded log macro), and ideally `snprintf` into a fixed buffer.
+
+## 🟡 Warnings (review case-by-case)
+- `src/foo.cpp:120` — function body 73 lines, exceeds 40-line guideline.
+
+## 🟢 Suggestions
+- `src/foo.cpp:200` — `if (x == -1)` could be clearer as `std::optional<int32_t>`.
+
+## ✅ Clean sections
+- §2 Types — all fixed-width.
+- §6 Reliability — all hardware inits return error codes.
+```
+
+## Rules
+
+- **Strict — no rounding down.** A real bug is a real bug.
+- **Cite line numbers.** If you can't point to a line, drop the finding.
+- **Only what's in the diff or directly tied to it.** Don't audit unrelated files.
+- **Never modify code.** Report only.

--- a/.claude/agents/firmware-architecture-reviewer.md
+++ b/.claude/agents/firmware-architecture-reviewer.md
@@ -1,0 +1,115 @@
+---
+name: firmware-architecture-reviewer
+description: Use when the diff adds new modules, interfaces, or services, or when reorganizing dependencies between modules. Verifies that the project's interface-decoupling rules are upheld (no direct cross-module includes, IPixelCanvas usage in effects, singleton wiring patterns, stateless services).
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are an architecture reviewer for Svitrix firmware. You verify that the project's decoupling discipline holds across the diff. You do NOT review embedded rules (that's `embedded-cpp-reviewer`'s job) or doc updates (that's `pr-reviewer`'s job) — you stay narrow.
+
+## Authoritative architecture rules
+
+From [/Users/bladerunner/Work/personal_projects/svitrix-firmware/CLAUDE.md](../../CLAUDE.md):
+
+1. **Interfaces everywhere** — `src/<ModuleA>/` never directly `#includes` headers from `src/<ModuleB>/`. All cross-module calls go through `lib/interfaces/src/I*.h`.
+2. **Singletons** — module classes have `= delete` copy/move. Use setter injection (`setXxx(I&)`) with `assert()` guards. **All wiring lives in `src/main.cpp`** — no implicit globals reaching out.
+3. **Effects → IPixelCanvas** — code under `src/effects/` cannot call `FastLED` / `Adafruit_NeoMatrix` / `Adafruit_GFX` directly. Only `IPixelCanvas` methods.
+4. **lib/services/ stateless** — service functions are pure: time/state in via parameters, no `millis()` / `WiFi.*` / globals. Must compile in `native_test` (no Arduino-only includes outside `#ifdef UNIT_TEST`).
+5. **DisplayManager is 3 classes** — `DisplayManager_` (coordinator) + `DisplayRenderer_` + `NotificationManager_`. Don't collapse them.
+6. **Hardware-specific code** is `#ifdef ULANZI` guarded.
+
+## Process
+
+### 1. Find architecturally relevant changes
+```bash
+git diff --name-only main..HEAD -- 'src/*' 'lib/interfaces/*' 'lib/services/*'
+```
+If none — report "no architectural changes" and stop.
+
+### 2. Run these scans
+
+**Cross-module direct includes** (rule 1):
+```bash
+git diff main..HEAD -- 'src/*' | grep -E '^\+#include' | grep -E '"\.\./(DisplayManager|MQTTManager|ServerManager|PeripheryManager|MenuManager|UpdateManager|PowerManager|DataFetcher|MatrixDisplayUi|Apps|MelodyPlayer|effects|Overlays|policies)'
+```
+Any match → 🔴 issue: cross-module include bypasses the interface layer. Suggest the right `I*` interface.
+
+**FastLED / NeoMatrix inside effects** (rule 3):
+```bash
+git diff main..HEAD -- 'src/effects/*.cpp' | grep -E '^\+.*(FastLED\.|NeoMatrix|matrix\.set|Adafruit_GFX|Adafruit_NeoPixel)'
+```
+Any match (outside `NeoMatrixCanvas.h` itself) → 🔴 issue: effects must use `IPixelCanvas`.
+
+**Globals/time in services** (rule 4):
+```bash
+git diff main..HEAD -- 'lib/services/*' | grep -E '^\+.*(millis\(\)|WiFi\.|MATRIX|DISPLAY_MANAGER|extern\s)'
+```
+Any match → 🔴 issue: service is no longer stateless.
+
+**Service uses Arduino-only headers without UNIT_TEST guard** (rule 4):
+```bash
+grep -L '#ifdef UNIT_TEST' lib/services/src/*.h
+```
+(Headers that don't have the guard at all are fine if they include only standard headers — `Read` them and check.)
+
+**New `I*.h` in `lib/interfaces/src/`** (rule 1):
+For each new interface, verify:
+- It is `pure virtual` only (no implementation in the header beyond `= 0` virtuals and trivial getters).
+- A provider class exists somewhere implementing it.
+- It is wired in `src/main.cpp` (grep for the interface name there).
+
+**Singleton wiring** (rule 2): if `src/main.cpp` changed, verify new singletons:
+- Are added in a `Module.set...(...)` style block in `setup()`, NOT in constructors.
+- Have `= delete` copy/move (`Read` the new module's class declaration).
+
+**3-class DisplayManager** (rule 5): if `src/DisplayManager/` changed, the diff should not introduce a 4th class or merge two of the existing three.
+
+### 3. Verify the Interface Wiring table in CLAUDE.md still holds
+The root `CLAUDE.md` has an "Interface Wiring" table. For every new interface or new consumer:
+- If you added a new provider→consumer relationship → the table should be updated in the same branch.
+- Flag missing table updates as 🟡 warning.
+
+### 4. SOLID at the boundary level
+Beyond the explicit project rules, apply Clean Architecture / SOLID at architectural seams:
+
+- **SRP at module level** — a module under `src/<X>/` should have ONE reason to change. If the diff makes a module change for two unrelated reasons (e.g., MQTT logic AND HTTP routing in the same commit on `ServerManager`), suggest a split or escalate to design discussion.
+- **DIP** — concrete classes depend on `I*` interfaces, not other concretes. New cross-module direct includes are already caught above; here also flag when an interface declaration leaks a concrete type from another module in its method signatures.
+- **OCP** — new effects/policies/apps/services should plug into existing extension points (`EffectRegistry`, `IDisplayPolicy`, `lib/services/`) without touching unrelated code. If the diff modifies an extension-point's switch/dispatch logic to add a case rather than registering through the documented mechanism — flag.
+- **ISP** — interfaces stay narrow. Adding 5+ methods to an existing `I*` interface in one PR is a warning; consider whether the new methods belong on a separate interface (cf. existing split of `IDisplayControl` vs `IDisplayNavigation`).
+
+### 5. ADR coverage for new architectural decisions
+For each of these PR signatures, verify a corresponding ADR exists in `adr/` (or that the PR adds one):
+- New interface in `lib/interfaces/src/`
+- New top-level module under `src/`
+- Change to the persistence model (NVS layout, LittleFS structure)
+- New external protocol integration (new MQTT topic family, new HTTP API surface, new external data source)
+- Change to the wiring/composition pattern in `src/main.cpp`
+
+Flag missing ADRs as 🟡 warning, citing the template in `adr/README.md`.
+
+## Output
+
+```markdown
+# Architecture review
+
+Files in scope: N (src/X, lib/interfaces/Y, lib/services/Z)
+
+## 🔴 Architecture violations
+- `src/MenuManager/MenuManager.cpp:14` — `#include "../DisplayManager/DisplayManager.h"` bypasses interface. Use `IDisplayControl` (already injected via setter).
+- `src/effects/NewEffect.cpp:42` — calls `FastLED.setBrightness(...)`. Effects must use `IPixelCanvas` only.
+
+## 🟡 Warnings
+- `lib/interfaces/src/INewThing.h` introduced but no consumer wired in `src/main.cpp`.
+- Interface Wiring table in root CLAUDE.md does not list `INewThing` → `Consumer`.
+
+## 🟢 Clean
+- Interface decoupling intact across N changed src/ modules.
+- lib/services/ files remain stateless and native-test-compatible.
+- Singleton wiring in main.cpp uses setter injection.
+```
+
+## Rules
+
+- **Stay narrow** — defer embedded C++ violations to `embedded-cpp-reviewer`, doc gaps to `pr-reviewer`.
+- **Be concrete** — cite the file and line and quote the offending pattern.
+- **Read-only.**

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,143 @@
+---
+name: pr-reviewer
+description: Use PROACTIVELY when the user asks to review a PR/branch/diff for this firmware project, before merging, or before creating a release. Performs an end-to-end PR review combining embedded C++ rules, architecture rules, test adequacy, and doc-sync checks. Returns a structured report grouped by severity.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior firmware reviewer for the Svitrix project — an ESP32 / Arduino C++17 embedded codebase. Your job is to perform a **single comprehensive review pass** of a branch or PR and produce a structured report. You **never modify files** — you only read, search, and report.
+
+## Inputs
+
+The invoker provides one of:
+- A PR number (`#42` or URL) — fetch with `gh pr view <N> --json files,commits,title,body` and `gh pr diff <N>`
+- A branch name — diff against `main`: `git diff main..<branch>`
+- Nothing — review the current feature branch: `git diff main..HEAD`
+
+## Process
+
+Run these checks IN ORDER. Stop early only if step 1 finds the branch is empty.
+
+### 1. Scope discovery
+```bash
+git log --oneline main..HEAD
+git diff --name-only main..HEAD
+git diff --stat main..HEAD
+```
+Group changed files by area: firmware C++ (`src/`, `lib/`), web SPA (`web/`), tests (`test/`), docs (`*.md`, `docs/`), config (`platformio.ini`, `.claude/`, etc.). If the diff is empty, report "no changes" and stop.
+
+### 2. Embedded C++ rule audit (firmware C++ files only)
+Apply the rules from `~/Work/CLAUDE.md` (the embedded C++ rule sheet) plus the project-specific rules in `/Users/bladerunner/Work/personal_projects/svitrix-firmware/CLAUDE.md`. Flag any of the following as **ISSUES**:
+
+- `malloc` / `new` / `delete` outside of init code (heap fragmentation risk)
+- `std::string` / `std::vector` / `std::map` in runtime code (use static buffers)
+- C-style casts `(T)x` — must be `static_cast`/`reinterpret_cast`/`const_cast`
+- `int` / `long` / `short` instead of fixed-width `uint8_t` / `uint32_t` / etc.
+- Non-`volatile` access to ISR-shared state
+- Blocking calls inside ISRs (`printf`, mutex lock, `malloc`)
+- Missing `pdMS_TO_TICKS(...)` timeout on `xQueue*` / semaphore waits, or `portMAX_DELAY` without a comment explaining why
+- Recursion in firmware code
+- Hardware register accesses without `volatile`
+- `printf`/`sprintf`/`sscanf` in firmware code (use `snprintf` into a fixed buffer instead)
+- `dynamic_cast` in hot paths
+- New `static` buffers larger than ~1 KB without a `// @ <size>B, justification` comment
+- Anything in §[11] UB list (uninitialized vars, null deref, OOB array)
+
+### 3. Architecture audit (firmware only)
+Project-specific rules from `svitrix-firmware/CLAUDE.md`:
+
+- **Interface boundary**: a module under `src/<ModuleA>/` MUST NOT `#include "<ModuleB>.h"` directly — it must go through an interface in `lib/interfaces/src/I*.h`. Grep the diff for `#include "../<Module>` or `#include "src/<Module>` cross-module includes.
+- **Effects MUST use `IPixelCanvas`** — no direct `FastLED` or `NeoMatrix` calls inside `src/effects/`.
+- **Singletons** must `= delete` copy/move and use setter injection with `assert()` guards.
+- **lib/services/ stateless rule**: services must not call `millis()` directly or read globals — time/state passed as parameters. Services must compile in `native_test` (no Arduino-only includes outside `#ifdef UNIT_TEST` blocks).
+- **Hardware-specific code** must be guarded by `#ifdef ULANZI`.
+
+### 3a. Clean Code / SOLID audit
+Project standard (see `feedback_clean_code_architecture.md` in memory): code follows **Clean Code** and **Clean Architecture** principles, *within* the embedded constraints. Flag:
+
+- **SRP violation** — a single file/class changed for multiple unrelated reasons in this PR (e.g., parser logic + rendering tweaks landing in the same class). Suggest extraction.
+- **Function bloat** — new/modified functions > ~40 lines. Suggest splitting at logical seams.
+- **Naming smells** — abbreviations that hide intent (`hdl`, `mgr`, `tmp` for non-trivial values), inconsistent casing within a file, getter/setter that does work.
+- **DIP violation** — high-level module reaching into a concrete low-level type instead of an interface; e.g., `src/Apps/` directly calling a concrete `MQTTManager_` method that isn't on `INotifier` / `IButtonReporter`.
+- **OCP violation** — new feature added by modifying a switch/registry that already has a clean extension point. Example: adding a 21st effect by editing 5 places when `EffectRegistry` exists.
+- **LSP violation** — an interface implementor that throws/asserts/returns nullptr where the contract promised valid behavior.
+- **ISP violation** — a new fat interface combining concerns that could be split (`IDisplayControl` + `IDisplayNavigation` are already split — keep that pattern).
+- **Hidden side effects** — a function named like a query (`getX`, `isReady`) that mutates state.
+- **Comment smells** — comments that explain *what* (already obvious from code) instead of *why*; commented-out code blocks left behind.
+
+These are **🟡 warnings** by default — flag, don't block. Promote to 🔴 if combined with an embedded-rule violation or if the violation breaks the module's contract.
+
+### 3b. ADR check
+If the PR introduces a meaningful architectural change (new interface, new top-level module, change to a wiring pattern, new persistence layer, protocol-level decision), check `adr/` for a matching record. If none exists — flag as 🟡 warning suggesting an ADR be added (template in `adr/README.md`).
+
+### 4. Test coverage check
+- Did the diff touch `lib/services/`? If yes — verify a matching `test/test_native/test_<name>/` was added or updated. lib/services/ MUST maintain 100% coverage.
+- Did the diff touch `src/effects/`? If yes — verify a test in `test/test_native/test_effects/` exists for the new effect.
+- Did the diff add a new `IPixelCanvas` consumer? Flag if no MockPixelCanvas-based test exists.
+
+### 5. Documentation sync check
+Cross-reference against the "Cross-module Impact Map" in root `CLAUDE.md`. For each changed area, the corresponding CLAUDE.md / README.md should be updated in the same branch:
+
+| Changed | Doc that must follow |
+|---|---|
+| `lib/config/ConfigTypes.h` fields | `lib/config/CLAUDE.md` + `Globals.cpp` + ServerManager API + web types |
+| `lib/interfaces/src/I*.h` | `lib/interfaces/CLAUDE.md` + all implementors/consumers |
+| `src/effects/` new effect | `src/effects/README.md` + effect count refs |
+| `src/MQTTManager/` new entity | `src/MQTTManager/CLAUDE.md` |
+| `web/src/api/types.ts` | `SettingsContext.tsx` consumers |
+| New module | root `CLAUDE.md` Project Structure tree |
+
+Flag any change with no matching doc update as a **WARNING** (not always required, but worth checking).
+
+### 6. Conventional commits check
+Run `git log main..HEAD --format='%s'` and check every subject:
+- Format: `<type>[(scope)][!]: <description>`
+- Allowed types: `feat fix refactor perf docs test chore build ci style`
+- Subject under 72 chars
+- No `Co-Authored-By:` lines (per project rule) — `git log main..HEAD --format='%b' | grep -c Co-Authored-By` should be 0
+- Breaking changes use `!` or `BREAKING CHANGE:` footer
+
+### 7. Build & test signal
+If the changeset includes C++ files, recommend (don't run) `pio run -e ulanzi` and `pio test -e native_test` before merge.
+
+## Output format
+
+Produce ONE report. Be specific — every finding cites a file and line. Sort by severity.
+
+```markdown
+# PR review: <branch or PR title>
+
+**Scope:** N commits, M files changed
+- Firmware C++: <count>
+- Web SPA: <count>
+- Tests: <count>
+- Docs: <count>
+
+## 🔴 Issues (must fix before merge)
+- `src/foo.cpp:42` — uses `malloc` after init. Replace with static buffer per CLAUDE.md §[1].
+- `lib/services/Bar.cpp:17` — calls `millis()` directly, violates stateless services rule.
+
+## 🟡 Warnings (likely to fix)
+- `src/effects/NewEffect.cpp` — no test in `test/test_native/test_effects/`.
+- Commit `abc1234` — subject "Fixed bug" doesn't follow conventional commits (`fix(scope): description`).
+
+## 🟢 Suggestions (optional)
+- Consider extracting the JSON parsing block in `src/Foo.cpp:120-180` into `lib/services/`.
+
+## ✅ Looks good
+- 15 interfaces, all implementors compile.
+- Tests added for `lib/services/NewService.cpp`.
+- Conventional commit format followed throughout.
+
+## Recommended next steps
+- [ ] Address red issues
+- [ ] Run `pio test -e native_test && pio run -e ulanzi`
+- [ ] Update <doc> for the new <thing>
+```
+
+## Rules
+
+- **Read-only**: never `Edit` or `Write`. If asked to fix something, return findings and let the main session handle the fix.
+- **No speculation**: every finding must reference a real file path and line. If you can't quote it, drop it.
+- **Project-specific over generic**: prefer rules from `svitrix-firmware/CLAUDE.md` over generic best practices. This is embedded — the rules are tighter.
+- **Be concise**: this is a checklist, not an essay. Most findings should be 1 line.

--- a/.claude/commands/add-effect.md
+++ b/.claude/commands/add-effect.md
@@ -2,7 +2,9 @@
 description: Add a new visual effect following the IPixelCanvas pattern
 ---
 
-Guide through adding a new visual effect to the Svitrix firmware. Currently there are 20 effects.
+Guide through adding a new visual effect to the Svitrix firmware.
+
+> Verify the current count before writing docs: `grep kNumEffects src/effects/EffectRegistry.h`.
 
 ## Before starting
 
@@ -48,8 +50,8 @@ Guide through adding a new visual effect to the Svitrix firmware. Currently ther
    IMPORTANT: Check flash size after — effects add to binary size.
 
 8. **Update documentation:**
-   - Update `src/effects/README.md` — add effect to the list
-   - Update effect count in root `CLAUDE.md` (currently says 20)
+   - Update [src/effects/README.md](../../src/effects/README.md) — add effect to the list
+   - Update effect count in root [CLAUDE.md](../../CLAUDE.md) if it's referenced there
 
 ## IPixelCanvas API reference (quick)
 ```cpp

--- a/.claude/commands/add-ha-entity.md
+++ b/.claude/commands/add-ha-entity.md
@@ -2,7 +2,9 @@
 description: Step-by-step guide to add a new Home Assistant entity with MQTT auto-discovery
 ---
 
-Guide through adding a new Home Assistant entity to the Svitrix firmware. Currently there are 25 HA entities.
+Guide through adding a new Home Assistant entity to the Svitrix firmware.
+
+> Verify the current entity inventory in [src/MQTTManager/CLAUDE.md](../../src/MQTTManager/CLAUDE.md) before writing docs.
 
 ## Before starting
 

--- a/.claude/commands/flash-size.md
+++ b/.claude/commands/flash-size.md
@@ -2,7 +2,9 @@
 description: Analyze firmware binary size and partition layout in detail
 ---
 
-Perform a detailed analysis of the firmware flash usage. This is critical — flash is ~96% full.
+Perform a detailed analysis of the firmware flash usage.
+
+> Compute the current usage from the build output below — do NOT rely on any baked-in number. Project rule: flash is comfortable; do not panic-optimize unless `> 90%`.
 
 ## Steps
 
@@ -59,8 +61,8 @@ Perform a detailed analysis of the firmware flash usage. This is critical — fl
    ```
 
 8. **If CRITICAL**, suggest optimization strategies:
-   - Check for unused effects (19 effects may not all be needed)
+   - Check for unused effects in [src/effects/EffectRegistry.cpp](../../src/effects/EffectRegistry.cpp) — drop unused entries
    - Check for large string literals or lookup tables
-   - Review lib_deps for unused libraries
+   - Review `lib_deps` in [platformio.ini](../../platformio.ini) for unused libraries
    - Consider `-Os` vs `-Oz` optimization
-   - Check if games are accidentally included (should be excluded by build_src_filter)
+   - Check that games are excluded by `build_src_filter` in [platformio.ini](../../platformio.ini)

--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -53,13 +53,13 @@ Analyze ALL changes on the current feature branch vs main and update every affec
      - Changed dependency wiring in `main.cpp`
 
 4. **Update counts across all docs:**
-   Verify these numbers match reality:
-   - HA entities count (currently 25) — check `src/MQTTManager/`
-   - Effects count (currently 19) — check `src/effects/`
-   - API endpoints count — check `src/ServerManager.cpp`
-   - Test suites/tests count — run `pio test -e native_test --list-tests` or count test files
-   - Interface count (currently 13) — check `lib/interfaces/`
-   - Service count (currently 14) — check `lib/services/`
+   Re-compute these from the code (do NOT trust numbers in existing docs — assume they may be stale):
+   - HA entities — count entity registrations in `src/MQTTManager/` + `lib/services/HADiscovery/`
+   - Effects — `grep kNumEffects src/effects/EffectRegistry.h`
+   - API endpoints — `grep -cE 'server\\.on\\(' src/ServerManager/*.cpp`
+   - Test suites/tests — `ls test/test_native/ | wc -l` and `pio test -e native_test --list-tests` if installed
+   - Interfaces — `ls lib/interfaces/src/I*.h | wc -l`
+   - Services — count unique service names (excluding .h/.cpp pairs) in `lib/services/src/`
 
 5. **Update root CLAUDE.md if architecture changed:**
    - New module added → update Project Structure tree

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -52,8 +52,8 @@ Scan recent code changes and update the corresponding CLAUDE.md / README.md file
      - New dependencies or wiring changes
 
 4. **Verify consistency:**
-   - Cross-check counts: "25 HA entities", "19 effects", "33 endpoints", etc.
-   - Verify interface lists match actual code
+   - Cross-check counts against the code itself, not against numbers in existing docs (they rot fast)
+   - Verify interface lists match actual files in `lib/interfaces/src/`
    - Check that module dependency graph in root CLAUDE.md is still accurate
 
 5. **Report what was updated:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,67 @@
+<!--
+Thanks for contributing to Svitrix! Please fill in the sections below.
+Keep it concise — reviewers care about WHY more than WHAT.
+Delete sections that don't apply.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what changes and why. Link the issue if there is one. -->
+
+-
+-
+
+## Changes
+
+<!-- High-level list of touched modules / behavior. Group by area when useful. -->
+
+-
+-
+
+## Test plan
+
+<!-- How did you verify this works? Include exact commands and what you saw. -->
+
+- [ ] `pio test -e native_test` passes
+- [ ] `pio run -e ulanzi` builds successfully
+- [ ] Manual verification on hardware (if behavior is observable on device)
+
+<!-- Add module-specific checks below, e.g.:
+- [ ] Effect rendered correctly in `tools/render_effect/` GIF output
+- [ ] HA entity appears in MQTT discovery and reacts to commands
+- [ ] Settings page in SPA round-trips values to NVS
+-->
+
+## Binary size
+
+<!-- Run `/flash-size` (Claude Code) or `pio run -e ulanzi -v` and paste app/spiffs deltas.
+Significant size changes (>1%) should be explained. Delete this section for docs-only PRs. -->
+
+| Section | Before | After | Delta |
+|---------|--------|-------|-------|
+| app     |        |       |       |
+
+## Breaking changes
+
+<!-- Anything that breaks existing configs, MQTT topics, REST endpoints, NVS layout,
+or HA entity IDs? If so, describe the migration path. Otherwise: "None." -->
+
+None.
+
+## Documentation
+
+<!-- Which docs were updated alongside the code? -->
+
+- [ ] Module-level `CLAUDE.md` updated (if architecture changed)
+- [ ] Root `CLAUDE.md` Cross-module Impact Map / wiring tables updated (if interfaces changed)
+- [ ] Public docs in `docs/` updated (if user-visible behavior changed) — use `/sync-public-docs`
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] ADR added under `adr/` (if architectural decision)
+
+## Checklist
+
+- [ ] Branch name follows `feat/…`, `fix/…`, `refactor/…`, `docs/…` convention
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No `Co-Authored-By:` lines (per [git-workflow](.claude/git-workflow.md))
+- [ ] No secrets, API keys, or personal Wi-Fi/MQTT credentials in the diff
+- [ ] Respects embedded constraints (no runtime heap, no blocking in ISR, fixed-width types)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,34 @@ jobs:
             --quiet \
             src/
 
+  clang-tidy:
+    name: Clang-Tidy (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-tidy
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy-18
+
+      - name: Run clang-tidy on lib/services/
+        # Scope: lib/services/ only — pure C++ that compiles without ESP32 toolchain.
+        # Mode: advisory (continue-on-error above). Tighten the gate by removing
+        # continue-on-error once the codebase is clean. Add other paths to the
+        # globbed list when their headers don't need xtensa-specific resolution.
+        run: |
+          mapfile -t files < <(git ls-files 'lib/services/src/*.cpp')
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No lib/services/ files matched, skipping."
+            exit 0
+          fi
+          clang-tidy-18 --quiet "${files[@]}" -- \
+            -std=c++17 \
+            -DUNIT_TEST \
+            -Ilib/services/src \
+            -Ilib/interfaces/src
+
   test:
     name: Unit Tests (native)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ compile_commands.json
 .claude/settings.json
 .claude/settings.local.json
 
+# CodeGraph index (rebuildable from source; not for version control)
+.codegraph/
+
 # OS
 .DS_Store
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to Svitrix firmware are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+with pre-release tags (see [.claude/git-workflow.md](.claude/git-workflow.md)).
+
+## [Unreleased]
+
+### Added
+- ADR scaffolding under `adr/` documenting key architectural decisions (interface decoupling, 3-class DisplayManager, stateless services, Clean Code standard, Signed OTA Phase 1).
+- `ResetReason` service — captures `esp_reset_reason()` at boot and surfaces it in `/stats` JSON as `reset_reason` (readable in Home Assistant via template sensor).
+- `SignatureVerifier` service and Signed OTA **Phase 1** scaffolding — `verifyUpdateSignature` config flag, embedded public-key slot (`src/data/ota_pubkey.h`), `.sig` URL convention, structural pre-check in `UpdateManager`. **Not yet cryptographically protective** — see [ADR 0005](adr/0005-signed-ota-phase-1.md) Phase 2.
+- Read-only PR-review sub-agents: `pr-reviewer`, `embedded-cpp-reviewer`, `firmware-architecture-reviewer`.
+- Community files: `SECURITY.md` (vulnerability disclosure policy), `CONTRIBUTING.md` (local-dev + design rules), `.github/PULL_REQUEST_TEMPLATE.md`.
+- CI `clang-tidy` advisory job scoped to `lib/services/src/` (continue-on-error initially).
+
+### Fixed
+- **Security:** format-string injection in UDP discovery and `DataFetcher` (#54).
+
+## [0.3.1] — 2026-04-26
+
+### Changed
+- CI release workflow now bundles `littlefs.bin` (SPA) alongside `firmware.bin` in release artifacts (#51).
+
+## [0.3.0] — 2026-04-26
+
+### Added
+- Scheduled night mode with brightness and color override (#45).
+- Fire effect and background effect picker (#49).
+- Configurable icon layout (left / right / none).
+- `/parallel` and `/delegate` Claude Code slash commands for multi-agent workflows.
+- "Cross-module Impact Map" and "Common Change Patterns" tables in root `CLAUDE.md` to speed up new-feature work.
+
+### Changed
+- SPA rewritten with a proper component library, settings sections, and theming.
+- CI auto-injects the firmware version from a `version` file (#50).
+- `src/` restructured into module directories.
+- Docs deploy only on release, not on every push to `main`.
+- `CLAUDE.md` hierarchy reorganized for on-demand loading (#46).
+
+### Removed
+- Games module — out of scope for a display-first device.
+
+## [0.2.0] — 2026-04-12
+
+### Added
+- `DataFetcher` module — external HTTP data sources polled in round-robin (#18).
+- New Preact + Vite SPA served from LittleFS, replacing the legacy web UI.
+- Module-level `CLAUDE.md` documentation for every top-level module (#20).
+- Claude Code slash commands and commit linting (#30).
+
+### Changed
+- C++ standard upgraded from C++11 to C++17.
+- Font system replaced with a Unicode sparse glyph table and UTF-8 rendering.
+- Documentation refreshed across `CLAUDE.md` files and project metadata (#29, #31).
+
+### Fixed
+- MQTT: Home Assistant entity memory is now freed before re-allocation in `setup()`, preventing a leak across reconnects.
+
+## [0.1.0] — 2026-03-07
+
+### Added
+- Initial public release of Svitrix firmware for the Ulanzi TC001 Smart Pixel Clock and compatible 32×8 LED matrix devices.
+- Pre-installed apps (time, date, temperature, humidity, battery), MQTT + HTTP API, Home Assistant auto-discovery, web UI with WiFi setup and OTA, 19 visual effects, weather overlays, RTTTL melodies, animated icons, drawing API, charts, indicators, mood light, on-screen menu, Artnet/DMX receiver, custom palettes, online flasher, backup/restore.
+
+[Unreleased]: https://github.com/svitrix/svitrix-firmware/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/svitrix/svitrix-firmware/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/svitrix/svitrix-firmware/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/svitrix/svitrix-firmware/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/svitrix/svitrix-firmware/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Per-module docs auto-load when you Read files in their directory.
 | Module | Doc | Role |
 |--------|-----|------|
 | Interfaces | [lib/interfaces/CLAUDE.md](lib/interfaces/CLAUDE.md) | 15 pure-virtual interfaces (decoupling layer) |
-| Services | [lib/services/CLAUDE.md](lib/services/CLAUDE.md) | 15 stateless libs, 100% test coverage |
+| Services | [lib/services/CLAUDE.md](lib/services/CLAUDE.md) | 17 stateless libs, 100% test coverage |
 | Config | [lib/config/CLAUDE.md](lib/config/CLAUDE.md) | Config structs, defaults, persistence |
 | HA integration | [lib/home-assistant-integration/CLAUDE.md](lib/home-assistant-integration/CLAUDE.md) | ArduinoHA fork, entity types enabled |
 | Webserver | [lib/webserver/CLAUDE.md](lib/webserver/CLAUDE.md) | Async server wrapper, WiFi, SPA fallback |
@@ -225,6 +225,22 @@ Prefer these over manual multi-step workflows — each is a tested, opinionated 
 | `/pr` | Create a structured GitHub PR from the current feature branch |
 | `/release` | Interactive beta/rc/stable release workflow |
 | `/changelog` | Generate changelog from conventional commits (since last tag or range) |
+
+## Sub-agents (review)
+
+Project-local agents in [.claude/agents/](.claude/agents/) — all read-only. Dispatch via the `Agent` tool with `subagent_type: <name>`.
+
+| Agent | Use when |
+|-------|----------|
+| `pr-reviewer` | Reviewing a PR/branch/diff end-to-end (embedded + arch + tests + docs + conventional commits). Default choice for "review this PR". |
+| `embedded-cpp-reviewer` | C++-heavy diff. Strict audit against the embedded rule sheet (heap, ISR, fixed-width types, banned funcs, UB). |
+| `firmware-architecture-reviewer` | New modules / interfaces / services. Verifies interface decoupling, IPixelCanvas usage, stateless services, singleton wiring. |
+
+`pr-reviewer` covers the common case. The other two are deeper second-pass tools for focused audits.
+
+## CodeGraph
+
+`.codegraph/` is initialized — semantic graph of the codebase. For broad exploration questions ("how does X work?", "where is Y implemented?"), spawn an Explore agent that uses `codegraph_explore` (see global `~/.claude/CLAUDE.md` for rules). The main session uses only lightweight tools (`codegraph_search`, `codegraph_callers`, `codegraph_impact`) for targeted lookups.
 
 ## Git & Release
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at oleksandr.slukovskyi@gmail.com (subject prefix: [svitrix-conduct]). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to Svitrix
+
+Thanks for your interest in contributing. Svitrix is custom firmware for the [Ulanzi TC001 Smart Pixel Clock](https://www.ulanzi.com/) (and compatible 32×8 LED matrix devices), built around an ESP32 with Arduino / PlatformIO.
+
+This document covers the local-dev setup and the conventions reviewers will check. If you're looking for the *what* and the *why* of the architecture, read [CLAUDE.md](CLAUDE.md) at the repo root and the per-module docs it links to.
+
+## Quick start
+
+```bash
+# clone + open
+git clone https://github.com/svitrix/svitrix-firmware.git
+cd svitrix-firmware
+
+# native unit tests (no hardware needed) — should pass before any PR
+pio test -e native_test
+
+# build firmware (auto-builds the web SPA via tools/build_web.py)
+pio run -e ulanzi
+
+# optional: full local CI pipeline (tests + build + flash-size check)
+# inside a Claude Code session: /build
+```
+
+The two things that matter for a clean PR:
+1. `pio test -e native_test` passes
+2. `pio run -e ulanzi` succeeds and stays under ~90% flash usage
+
+A pre-commit hook ([.pre-commit-config.yaml](.pre-commit-config.yaml)) catches the common issues — install with `pip install pre-commit && pre-commit install`.
+
+## Project layout
+
+See [CLAUDE.md § Project Structure](CLAUDE.md#project-structure). High-level:
+
+| Directory | What's there |
+|-----------|--------------|
+| `src/` | Stateful modules (DisplayManager, MQTTManager, ServerManager, …) |
+| `lib/interfaces/` | Pure-virtual `I*.h` decoupling layer ([ADR 0001](adr/0001-interface-decoupling.md)) |
+| `lib/services/` | Stateless utility libraries with 100% test coverage ([ADR 0003](adr/0003-stateless-services.md)) |
+| `lib/config/` | Config struct definitions |
+| `web/` | Preact SPA served from LittleFS |
+| `test/test_native/` | Native unit tests (Unity, runs on host) |
+| `adr/` | [Architecture Decision Records](adr/README.md) — read these before proposing structural changes |
+| `docs/` | Public VitePress documentation |
+
+## Design rules
+
+These are non-negotiable — PRs that violate them will be sent back for revision.
+
+### Embedded C++ constraints
+See `~/Work/CLAUDE.md` (auto-loaded for AI sessions, but applies to humans too): no `malloc` after init, no runtime `std::string`/`std::vector` in hot paths, no exceptions, fixed-width types only, ISR safety. Summary in [CLAUDE.md § Architecture Rules](CLAUDE.md#architecture-rules).
+
+### Architecture
+- **Modules talk through interfaces, not direct includes.** See [ADR 0001](adr/0001-interface-decoupling.md).
+- **Effects use `IPixelCanvas`, never FastLED/NeoMatrix directly.** Effects must be testable with `MockPixelCanvas` ([ADR 0001](adr/0001-interface-decoupling.md)).
+- **Stateless services don't call `millis()` or read globals.** Pass time/state as parameters ([ADR 0003](adr/0003-stateless-services.md)).
+- **DisplayManager stays split into 3 classes** — don't collapse them ([ADR 0002](adr/0002-three-class-display-manager.md)).
+- **All wiring lives in `src/main.cpp`** — modules don't reach out to other modules at construction time.
+
+### Code style
+- **Clean Code & SOLID** ([ADR 0004](adr/0004-clean-code-and-architecture.md)) — meaningful names, small functions, one reason to change per file.
+- **`clang-format`** runs in pre-commit and CI. Style file at [.clang-format](.clang-format).
+- **`clang-tidy`** advisory check in CI ([.clang-tidy](.clang-tidy)). New issues will be flagged but don't (yet) block merge — that's coming.
+- **Comments** — only when WHY isn't obvious. Don't restate WHAT the code does.
+
+## Tests
+
+- Every new function in `lib/services/` needs a Unity test under `test/test_native/test_<name>/`. Coverage stays at 100%.
+- Every new effect in `src/effects/` needs a test that uses `MockPixelCanvas`.
+- For module-level changes (DisplayManager, MQTTManager, …), tests are encouraged where the surface is testable without a physical device.
+
+Run with `pio test -e native_test`.
+
+## Commits and PRs
+
+Conventional Commits format. Detailed rules in [.claude/git-workflow.md](.claude/git-workflow.md). Short version:
+
+```
+<type>(<scope>): <description>
+
+<body — explain WHY, not WHAT>
+
+<optional: Refs: #123>
+```
+
+- `type` ∈ `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`
+- Subject ≤ 72 chars, imperative mood, no trailing period
+- **No `Co-Authored-By:` lines** — we don't use them on this project
+
+Branch from `main`, work on `feature/<descriptive-name>`, squash-merge via PR. PR title follows the same Conventional Commits format.
+
+Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — it has a checklist.
+
+## Documentation
+
+If your change affects user-visible behavior, update the relevant docs in the same PR:
+
+- **Public docs (`docs/`):** end-user facing, VitePress, English + Ukrainian translations. Use `/sync-public-docs` slash command in Claude Code, or update manually.
+- **AI-reference docs (`CLAUDE.md`, `README.md`):** internal architecture docs, used by Claude Code sessions. Use `/sync-docs` slash command, or update manually.
+- **ADRs:** propose a new `adr/000N-...md` when introducing a meaningful architectural change (new top-level module, new interface, new persistence layer, new protocol integration). Template and rules in [adr/README.md](adr/README.md).
+
+## Sub-agents and slash commands (Claude Code)
+
+If you use Claude Code, this project ships:
+- `/build` — full local CI (tests + firmware + size check)
+- `/add-effect`, `/add-ha-entity`, `/add-service` — opinionated recipes
+- `/pr`, `/release`, `/changelog` — release workflow
+- `pr-reviewer`, `embedded-cpp-reviewer`, `firmware-architecture-reviewer` — read-only review sub-agents
+
+Listed in [CLAUDE.md § Available Skills](CLAUDE.md#available-skills) and [CLAUDE.md § Sub-agents](CLAUDE.md#sub-agents-review).
+
+## Reporting bugs and proposing features
+
+- **Bugs** → [Issue template](.github/ISSUE_TEMPLATE/bug_report.yml)
+- **Features** → [Issue template](.github/ISSUE_TEMPLATE/feature_request.yml)
+- **Questions / ideas** → [GitHub Discussions](https://github.com/svitrix/svitrix-firmware/discussions)
+- **Security** → see [SECURITY.md](SECURITY.md) (please don't use public issues)
+
+## Code of conduct
+
+Participation is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — be respectful, assume good faith, focus on the work.
+
+## Questions
+
+Open a [Discussion](https://github.com/svitrix/svitrix-firmware/discussions) — there's no such thing as a question too small for a young project.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 SVITRIX is a smart home companion designed for HomeAssistant, IOBroker, NodeRed, and other automation systems. It works out of the box with pre-installed apps for time, date, temperature, humidity, and battery. For advanced users, the powerful MQTT and HTTP API allows creating custom apps, sending notifications, and controlling every aspect of the display.
 
-SVITRIX is a community-driven fork of the original [AWTRIX 3](https://github.com/Blueforcer/awtrix3) project, created to enable active development and accept contributions from the community.
+SVITRIX started as a fork of [AWTRIX 3](https://github.com/Blueforcer/awtrix3) and has since been substantially rewritten — interface-decoupled modules, stateless service libraries with native unit tests, a Preact-based web UI, and an ADR-driven architecture. The shared lineage stays in attribution and the inherited CC BY-NC-SA license; day-to-day development has diverged from upstream.
 
 > **Note:** In SVITRIX, "Custom Apps" are not traditional apps you install. They are dynamic pages that rotate on the display, showing content sent from an external system via MQTT or HTTP. All logic is handled by your smart home — SVITRIX provides the display.
 
@@ -131,7 +131,14 @@ SVITRIX is developed using an **AI-first** approach. [Claude](https://claude.ai)
 
 ## Contributing
 
-Star the repo, open issues, and submit pull requests — contributions are welcome!
+Contributions are welcome — star the repo, open issues, and submit pull requests.
+
+Before you start:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local-dev setup, design rules, commits & PR conventions
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards (Contributor Covenant)
+- [SECURITY.md](SECURITY.md) — how to report a vulnerability (please don't use public issues)
+- [CHANGELOG.md](CHANGELOG.md) — release history
 
 ## Disclaimer
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security policy
+
+## Supported versions
+
+Svitrix follows [SemVer](https://semver.org/) with pre-release tags (see [.claude/git-workflow.md](.claude/git-workflow.md)). Security fixes are backported to the most recent stable minor release; older minor versions are not patched.
+
+| Version | Supported |
+|---------|-----------|
+| latest stable `v0.x.0` | ✅ Yes |
+| previous stable | ⚠️ Critical fixes only |
+| pre-1.0 betas / RCs | ❌ Use the corresponding stable instead |
+
+Run `git tag --sort=-v:refname | head -5` (or check [Releases](https://github.com/svitrix/svitrix-firmware/releases)) to see what's current.
+
+## Reporting a vulnerability
+
+**Please do not open public GitHub issues for vulnerabilities.** A public issue tips off attackers before users can update.
+
+Use one of these private channels:
+
+1. **Preferred — GitHub Private Vulnerability Reporting:**
+   <https://github.com/svitrix/svitrix-firmware/security/advisories/new>
+   This creates a private advisory only visible to maintainers; we coordinate the fix and credit you in the published advisory.
+
+2. **Fallback — email** the maintainer at `oleksandr.slukovskyi@gmail.com` with the subject prefix `[svitrix-security]`. PGP key not yet published; if you need encrypted communication, mention it and we'll set one up.
+
+Include in your report:
+- Affected version(s) — exact tag if possible, otherwise commit hash
+- Reproduction steps or proof-of-concept
+- Impact and threat model (who can exploit, what they gain)
+- Suggested fix if you have one (optional)
+- Whether you intend to disclose publicly and on what timeline
+
+## What we commit to
+
+- **Acknowledge** receipt within **3 working days**.
+- **Initial assessment** (severity, scope) within **7 working days**.
+- **Patch + coordinated disclosure** for confirmed vulnerabilities — typically a stable release within **30 days** for high-severity, longer for complex changes that require breaking-change handling. We will keep you updated.
+- **Credit** in the GitHub Security Advisory and the relevant [CHANGELOG.md](CHANGELOG.md) entry, unless you request anonymity.
+
+## Scope
+
+In-scope for this policy:
+- Firmware code in `src/`, `lib/`, `tools/`, `web/`
+- Build / release tooling under `.github/workflows/`
+- Default configuration that ships with the firmware
+
+Out of scope:
+- Vulnerabilities in third-party dependencies — please report them upstream first, then notify us if a patch we ship is affected
+- User-supplied custom apps or dev.json configurations
+- Issues that require physical access to the device and direct access to its GPIO/USB-serial console (the threat model is that of a network-connected appliance, not a tamper-proof secure element)
+- ESP32 hardware silicon bugs (report to Espressif)
+
+## Known sharp edges
+
+These are documented limitations, not vulnerabilities, but listed here for transparency:
+
+- **OTA signature verification is partial** — `systemConfig.verifyUpdateSignature` (Phase 1) performs a structural check on a fetched signature file. Cryptographic verification against firmware bytes is Phase 2 work tracked in [ADR 0005](adr/0005-signed-ota-phase-1.md). Do not rely on Phase 1 for authenticity guarantees.
+- **No Secure Boot / Flash Encryption** — eFuses are not burned. Physical access allows full firmware extraction and replacement.
+- **MQTT credentials in NVS** — stored in plain text. NVS is not encrypted.
+
+## Hall of fame
+
+Reporters of confirmed vulnerabilities are listed here (or via the GitHub Security Advisory) once a fix is released. List will grow as advisories are published.
+
+— *(empty — be the first!)*

--- a/adr/0001-interface-decoupling.md
+++ b/adr/0001-interface-decoupling.md
@@ -1,0 +1,56 @@
+# ADR 0001: Interface decoupling via `lib/interfaces/`
+
+**Status:** Accepted
+**Date:** 2026-05-12
+
+## Context
+
+Svitrix firmware composes ~15 stateful modules (`DisplayManager`, `MQTTManager`, `ServerManager`, `PeripheryManager`, etc.) that must collaborate at runtime: the web server needs to push notifications to the display; the periphery manager needs to report button presses to both MQTT and HTTP; the display needs sensor readings; and so on.
+
+Three pressures shaped this decision:
+
+1. **Test isolation.** Stateless services in `lib/services/` are testable with `pio test -e native_test`, but stateful modules talk to FastLED, WiFi, AsyncWebServer — none of which run on host. Direct cross-module includes would make the entire dependency tree of any test target pull in Arduino, which doesn't compile natively.
+2. **Compile-time coupling cost.** A direct `#include "DisplayManager.h"` in `MQTTManager.cpp` makes touching `DisplayManager`'s header trigger recompilation of MQTT code. With ~15 modules and a ~7-second clean build, transitive recompiles add up quickly.
+3. **Cyclic dependencies.** Display → notifications → MQTT → display (re-broadcast state) is a real flow. Without indirection, the include graph forms a cycle that the linker tolerates but humans cannot reason about.
+
+## Decision
+
+Every cross-module call goes through a pure-virtual interface declared in `lib/interfaces/src/I*.h`. Concrete modules implement the interfaces they provide and accept interface references for the consumers they need. **All wiring lives in `src/main.cpp`** — modules never reach out to each other directly.
+
+Concretely:
+- Each `I*.h` is header-only, pure-virtual, no implementation.
+- Producer module exposes its collaborators through getters returning the concrete sub-object reference — e.g. `DisplayManager_::getRenderer()` → `DisplayRenderer_&`, `DisplayManager_::getNotifier()` → `NotificationManager_&`. The consumer takes the pointer typed as the interface; implicit upcast happens at the call site.
+- Consumer module has a setter taking interface pointers — e.g. `MQTTManager_::setDisplay(IDisplayControl*, IDisplayNavigation*, IDisplayNotifier*)`. Setters whose collaborators must be live before `tick()` start `assert()` their arguments; setters whose collaborator is optional (no-op when null) skip the assert.
+- `main.cpp::setup()` calls all setters in dependency order before any module starts ticking (see [src/main.cpp](../src/main.cpp) `setup()`).
+- The top-level publicly-instantiated module singletons (`DisplayManager_`, `ServerManager_`, `MQTTManager_`, `PeripheryManager_`, `PowerManager_`, `UpdateManager_`, `DataFetcher_`, `MenuManager_`) `= delete` copy/move to prevent accidental duplication. Sub-objects that live by composition inside a module (e.g. `DisplayRenderer_`, `NotificationManager_` inside `DisplayManager_`) don't need the same treatment — they are not standalone singletons.
+
+The complete provider→consumer wiring table is documented in [root CLAUDE.md](../CLAUDE.md#interface-wiring).
+
+## Consequences
+
+**Easier:**
+- Any module can be replaced with a `Mock*` for native tests (`test/test_native/test_idisplay/` exercises this).
+- Adding a new consumer requires no changes to the producer module's code — just a new wiring line in `main.cpp`.
+- Compile-time coupling is bounded by the interface header, which changes infrequently.
+- Cycles are broken by definition — the interface is a one-way contract.
+
+**Harder:**
+- Indirection adds boilerplate per interface (header + getter + setter + assert).
+- A function call goes through a vtable instead of being inlined — measurable cost only in hot paths (effects use the same pattern via `IPixelCanvas` and it's been fine at 30 FPS).
+- Wiring errors surface as `assert()` failures at startup rather than link errors — costs one boot cycle to discover.
+
+**Must live with:**
+- Discipline. The rule only works if it's never bypassed. The architecture-review agent ([.claude/agents/firmware-architecture-reviewer.md](../.claude/agents/firmware-architecture-reviewer.md)) enforces this on every PR.
+
+## Alternatives considered
+
+- **Global singletons accessed via `extern`**: simpler, what the original Awtrix firmware does. Rejected — makes testing impossible without `#ifdef UNIT_TEST` islands throughout production code, and creates implicit init-order dependencies that surface as random boot crashes when modules grow.
+- **Compile-time templates (CRTP / static polymorphism)**: zero-overhead but every consumer becomes a template, propagating into headers, and inflating binary size on a flash-constrained target. Rejected — the runtime cost of vtables is negligible here and the readability cost of templates is high.
+- **Mediator object**: one big `App` god-object holding all references and routing calls. Rejected — collapses SRP into a single 500-line class that everyone depends on, defeating the point.
+- **Event bus**: pub/sub with stringly-typed topics. Rejected for in-process calls — adds allocation, loses compile-time checks, and is harder to trace. MQTT already serves this role for external integrations.
+
+## References
+
+- See [lib/interfaces/CLAUDE.md](../lib/interfaces/CLAUDE.md) for the full interface catalog.
+- See [src/main.cpp](../src/main.cpp) `setup()` for the wiring sequence.
+- Related: [ADR 0003](0003-stateless-services.md) (stateless services use a simpler pattern — no interfaces needed since pure functions have no state to inject).

--- a/adr/0002-three-class-display-manager.md
+++ b/adr/0002-three-class-display-manager.md
@@ -1,0 +1,55 @@
+# ADR 0002: DisplayManager split into three classes
+
+**Status:** Accepted
+**Date:** 2026-05-12
+
+## Context
+
+The display subsystem has three distinct responsibilities that originally lived in one class:
+
+1. **Coordination** — running the app rotation, deciding what to draw on each frame, holding the `MatrixDisplayUi` state machine, owning brightness/power state.
+2. **Rendering** — converting logical draw operations into pixel writes on the `NeoMatrix` LED buffer (text, icons, transitions, gamma correction).
+3. **Notifications** — queueing transient overlays (incoming MQTT/HTTP notifications), priority handling, expiration timers.
+
+These had grown into a single ~1500-line class with mixed concerns. Symptoms:
+
+- Touching notification queueing logic could break app rendering (and did, repeatedly).
+- The class was untestable as a whole — its public API was a leaky abstraction over three unrelated state machines.
+- New developers (and AI sessions) couldn't predict where to make a change.
+
+## Decision
+
+Split into three cooperating classes, each in its own file under `src/DisplayManager/`:
+
+- **`DisplayManager_`** — coordinator. Owns the app rotation, the active `MatrixDisplayUi` instance, brightness state, and lifecycle (`tick()`, `setup()`). Holds references to the other two and dispatches to them.
+- **`DisplayRenderer_`** — pure rendering. All `matrixPrint()`, icon draws, transition blends, gamma, color correction. Implements `IDisplayRenderer`. No knowledge of apps or notifications.
+- **`NotificationManager_`** — notification lifecycle. Queue, priority, expiration. Implements `IDisplayNotifier`. Asks the renderer to draw when active, asks the coordinator for screen time.
+
+`DisplayManager_` is the publicly-instantiated singleton (`= delete` copy/move). `DisplayRenderer_` and `NotificationManager_` live by composition inside it — they are owned, never directly constructed by callers — so they don't carry the `= delete` boilerplate themselves. Wiring in [src/main.cpp](../src/main.cpp).
+
+## Consequences
+
+**Easier:**
+- Each class has one reason to change — SRP applies cleanly.
+- `DisplayRenderer_` is reusable: `UpdateManager`, `MenuManager`, `ServerManager` all consume `IDisplayRenderer` for their own UI without going through coordination logic.
+- Notification logic is testable in isolation through the `IDisplayNotifier` interface — `test/test_native/test_idisplay/` exercises `test_notifier_dismiss`, `test_notifier_indicator_state`, `test_notifier_indicator_color` against a mock implementation, no FastLED / NeoMatrix link required.
+- The split keeps the coordinator and notification manager small (≲300 LOC each). The renderer and the custom-apps file drift longer because they accumulate effect / parser tables — that's acceptable: they grow along a single axis (more effects / more parser branches), not along multiple responsibilities.
+
+**Harder:**
+- Three classes to onboard instead of one. Mitigated by [src/DisplayManager/CLAUDE.md](../src/DisplayManager/CLAUDE.md) explaining the split.
+- Coordinator must mediate between the other two — adds some delegation boilerplate.
+
+**Must live with:**
+- The split must not be re-collapsed. The architecture-review agent flags any attempt to merge two of the three or add a fourth class to this module.
+
+## Alternatives considered
+
+- **Keep as one class, refactor internally** — would only paper over the problem; SRP doesn't apply when one type holds three unrelated responsibilities behind a "convenient" public API.
+- **Two classes (`DisplayManager_` + `Renderer_`)** with notifications kept in the coordinator — rejected. Notification expiration logic is its own state machine and pollutes coordinator code; same testability problem.
+- **Four+ classes (split renderer into TextRenderer / GraphicsRenderer / TransitionRenderer)** — rejected as premature. The renderer is ~600 lines, navigable, and the sub-responsibilities are tightly coupled by shared canvas state.
+
+## References
+
+- [src/DisplayManager/CLAUDE.md](../src/DisplayManager/CLAUDE.md) — module doc explaining the three classes
+- [ADR 0001](0001-interface-decoupling.md) — the interface pattern this split relies on
+- Provider→consumer wiring in [root CLAUDE.md](../CLAUDE.md#interface-wiring)

--- a/adr/0003-stateless-services.md
+++ b/adr/0003-stateless-services.md
@@ -1,0 +1,52 @@
+# ADR 0003: Stateless service libraries under `lib/services/`
+
+**Status:** Accepted
+**Date:** 2026-05-12
+
+## Context
+
+Many useful computations in the firmware are pure functions that don't depend on hardware: color math, gamma correction, sensor calibration curves, MQTT message routing, HA discovery payload generation, text layout, format-string validation. Originally these were inline methods on stateful modules (`DisplayManager_::applyGamma()`, `MQTTManager_::routeMessage()`).
+
+Two problems with that arrangement:
+
+1. **Untestable on host.** A test for gamma correction shouldn't require linking FastLED, WiFi, and the AsyncWebServer. But because the methods were members of stateful classes pulled into those frameworks, native tests for pure logic were impossible.
+2. **Reuse blocked by ownership.** When `MQTTManager_` and `ServerManager_` both needed to format the same stats payload, the code was either duplicated or one module had to ask the other — creating an artificial dependency between two adapters.
+
+## Decision
+
+Pure logic lives in `lib/services/` as **stateless** libraries. Each service is an `.h` exporting free or namespaced functions, with a matching `.cpp` when bodies aren't trivially `inline` / `constexpr`. Rules:
+
+- **No state.** No globals, no statics holding mutable data, no `millis()`, no `WiFi.*`. Time and state come in via parameters.
+- **No Arduino-only headers** outside `#ifdef UNIT_TEST` blocks. Services must compile in the `native_test` environment.
+- **No ArduinoJson dependency in the service core** — build JSON manually if needed, or accept a `JsonObject&` from the caller. (ArduinoJson works in native_test but we keep services framework-free as a discipline.)
+- **Every service has a Unity test suite** under `test/test_native/test_<snake_case>/`. (Line/branch coverage is not measured in CI today — the rule is "no service ships without its own suite", enforced at PR review.)
+
+The current service catalog lives in [lib/services/CLAUDE.md](../lib/services/CLAUDE.md). Services are added without rewriting this ADR — what's fixed here is the rule, not the inventory.
+
+## Consequences
+
+**Easier:**
+- The whole native test suite runs on host in well under a minute, no hardware loop — fast enough to keep `pio test -e native_test` in the inner refactor loop.
+- A new contributor can read any service's `.h` + its test file in one sitting and understand the contract without grepping for hidden state.
+- Refactoring pure logic is safe — the test suite catches regressions immediately.
+- New consumers can use existing services without negotiating with their original "owner" module.
+- Services are easy to reason about: same input → same output, always.
+
+**Harder:**
+- Service functions take more parameters than equivalent member functions (`millis()` becomes `uint32_t nowMs`). Verbose at call sites; acceptable for the clarity gain.
+- A new service requires a new test suite. Friction by design — discourages putting one-off logic in `lib/services/` when it belongs in a module.
+
+**Must live with:**
+- The stateless rule is non-negotiable. Once a service calls `millis()` or reads a global, the test isolation collapses and the rule's value evaporates. The architecture-review agent enforces this.
+
+## Alternatives considered
+
+- **Static methods on stateful classes** — what we had. Rejected for the reasons above.
+- **Singletons under `lib/services/`** with init/teardown — gives stateful behavior to services. Rejected: defeats the purpose. If state is needed, it belongs in a module under `src/`, not in services.
+- **Free functions in `src/`** — would work but mixes "pure logic" with "modules". The `lib/` separation makes the rule visible at the directory level and gates inclusion of Arduino headers via `library.json`.
+
+## References
+
+- [lib/services/CLAUDE.md](../lib/services/CLAUDE.md) — service catalog and rules
+- [/add-service slash command](../.claude/commands/add-service.md) — recipe for adding a new service
+- [ADR 0001](0001-interface-decoupling.md) — interfaces for stateful modules (services don't need interfaces; pure functions have no state to inject)

--- a/adr/0004-clean-code-and-architecture.md
+++ b/adr/0004-clean-code-and-architecture.md
@@ -1,0 +1,65 @@
+# ADR 0004: Clean Code & Architecture as project standard
+
+**Status:** Accepted
+**Date:** 2026-05-12
+
+## Context
+
+The project has accumulated three layers of conventions:
+
+1. **Embedded C++ rules** in `~/Work/CLAUDE.md` (no malloc after init, fixed-width types, no exceptions, ISR discipline, banned functions) — non-negotiable, derived from the platform constraints of the ESP32 / FreeRTOS environment.
+2. **Project architecture rules** in [root CLAUDE.md](../CLAUDE.md) (interface decoupling, stateless services, `#ifdef ULANZI` for hardware-specific code) — already documented per [ADR 0001](0001-interface-decoupling.md), [ADR 0002](0002-three-class-display-manager.md), [ADR 0003](0003-stateless-services.md).
+3. **General software engineering quality** — was implicit. Tied to the developer's individual judgment, with no shared vocabulary or checklist.
+
+That third layer needs to be made explicit so that reviews, code-review agents, and future contributions converge on the same notion of "good code" rather than rediscovering it case by case.
+
+## Decision
+
+All implementations and design choices follow the principles from Robert C. Martin's **Clean Code** and **Clean Architecture**, applied *within* the embedded constraints.
+
+**At the implementation level (Clean Code):**
+- Meaningful names — functions and variables reveal intent
+- Small functions — one thing, one level of abstraction, ≤ ~40 lines (aligns with embedded rule §[12])
+- Comments explain *why*, not *what* — code that needs *what*-comments should be renamed instead
+- Pure functions / no hidden side effects in `lib/services/` (already enforced)
+- Errors as return values, no silent ignores (already enforced)
+- DRY, but not premature: three similar lines beat a wrong abstraction
+- Boy Scout Rule: leave touched code cleaner than found — within scope
+
+**At the design level (Clean Architecture / SOLID):**
+- **Dependency Rule** — source-code dependencies point inward; high-level policy doesn't depend on low-level detail. `src/<X>/` depends on `lib/interfaces/I*`, not on other `src/` modules.
+- **SRP** — one reason to change per class/file
+- **OCP** — extend via new effects / policies / services without modifying existing ones (e.g., `EffectRegistry`, `IDisplayPolicy`, `lib/services/`)
+- **LSP** — interface implementors honor the contract; no surprise asserts or null returns
+- **ISP** — small focused interfaces (`IDisplayControl` / `IDisplayNavigation` split is the canonical example)
+- **DIP** — depend on abstractions; setter-injected interfaces in `main.cpp` enforce this
+
+**Precedence when rules conflict:** embedded rules win. Clean Code idioms that contradict embedded constraints (exceptions, polymorphism in hot paths, virtual calls in ISR, dynamic dispatch in tight loops) are disallowed by the platform — apply Clean Code *within* that envelope, not around it.
+
+## Consequences
+
+**Easier:**
+- Reviewers (human and agent) have a named, shared standard to point at — instead of "this feels off", they can say "SRP: this class has three responsibilities".
+- Onboarding gets cheaper: a developer who already knows SOLID maps directly onto this codebase.
+- Decisions are easier to justify in commit messages and ADRs.
+
+**Harder:**
+- Higher bar for "good enough". Some quick hacks that would have shipped before will now get pushback.
+- Some Clean Code idioms (polymorphism via interfaces everywhere) need translation to the embedded reality (vtable cost, no exceptions). Requires judgment per case.
+
+**Must live with:**
+- The standard is enforced by [.claude/agents/pr-reviewer.md](../.claude/agents/pr-reviewer.md) §3a and [.claude/agents/firmware-architecture-reviewer.md](../.claude/agents/firmware-architecture-reviewer.md) §4 on every PR.
+
+## Alternatives considered
+
+- **No explicit standard, rely on taste** — what we had. Rejected: doesn't scale beyond the original author, and even for solo work the AI agents need a written reference.
+- **Adopt MISRA C++ 2008 or AUTOSAR C++14 in full** — too rigid for a hobby/prosumer LED clock; large parts of MISRA target safety-critical certification, not consumer firmware. The embedded rules in `~/Work/CLAUDE.md` already cover the MISRA subset that matters here.
+- **Google C++ Style Guide** — has useful pieces but is opinionated about choices (no exceptions, no streams) that we already enforce, and on others (smart pointers, ownership) that don't fit this environment. Cherry-picking from it is not a coherent standard.
+- **"Clean Code" only, no architecture-level principles** — leaves the bigger question of how modules relate unspoken. Architecture is where the costly mistakes are made; covering it explicitly is the higher-leverage half.
+
+## References
+
+- Robert C. Martin, *Clean Code* (2008) and *Clean Architecture* (2017)
+- Memory record: `feedback_clean_code_architecture.md` (project-level feedback)
+- [.claude/agents/pr-reviewer.md](../.claude/agents/pr-reviewer.md) §3a — Clean Code / SOLID audit checklist
+- [.claude/agents/firmware-architecture-reviewer.md](../.claude/agents/firmware-architecture-reviewer.md) §4 — SOLID at module boundaries

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,66 @@
+# Architecture Decision Records
+
+Lightweight records of architectural decisions taken on this project. Format based on [Michael Nygard's template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Why ADRs
+
+Code shows *what* the system does. Comments rot. Commit messages get buried. ADRs capture *why* a decision was made — the constraints, the trade-offs, the alternatives that were considered — so future-you (and future AI sessions) don't have to reverse-engineer the reasoning.
+
+ADRs are **immutable once accepted**. If a decision is revisited, write a new ADR that supersedes the old one. Never edit history.
+
+## When to write an ADR
+
+Write one when you take a decision that future-you will probably question. In this project, the trigger conditions match the architecture-review agent's checklist (see [.claude/agents/firmware-architecture-reviewer.md](../.claude/agents/firmware-architecture-reviewer.md) §5):
+
+- New interface in `lib/interfaces/src/`
+- New top-level module under `src/`
+- Change to persistence model (NVS layout, LittleFS structure, OTA partition table)
+- New external protocol integration (new MQTT topic family, new HTTP API surface, new external data source)
+- Change to wiring/composition pattern in `src/main.cpp`
+- Adoption of a project-wide standard (coding standard, dependency rule, release process)
+
+**Don't write ADRs for:** routine refactors, bug fixes, dependency bumps, doc-only changes, new visual effects (those plug into existing extension points).
+
+## Format
+
+Each ADR lives in `adr/NNNN-kebab-case-title.md` where `NNNN` is the next zero-padded number.
+
+```markdown
+# ADR NNNN: <Title>
+
+**Status:** Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+**Date:** YYYY-MM-DD
+
+## Context
+
+What forced this decision? What constraints were in play? Anything we tried and rejected before landing here?
+
+## Decision
+
+The chosen approach, stated clearly. One paragraph. No hedging.
+
+## Consequences
+
+What becomes easier, what becomes harder, what we now must live with. Include both the wins and the costs.
+
+## Alternatives considered
+
+Briefly: each alternative, why it was rejected.
+```
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](0001-interface-decoupling.md) | Interface decoupling via `lib/interfaces/` | Accepted | 2026-05-12 |
+| [0002](0002-three-class-display-manager.md) | DisplayManager split into three classes | Accepted | 2026-05-12 |
+| [0003](0003-stateless-services.md) | Stateless service libraries under `lib/services/` | Accepted | 2026-05-12 |
+| [0004](0004-clean-code-and-architecture.md) | Clean Code & Architecture as project standard | Accepted | 2026-05-12 |
+| [0005](0005-signed-ota-phase-1.md) | Signed OTA — Phase 1 (structural pre-check) | Accepted | 2026-05-13 |
+
+## Conventions
+
+- Numbering is monotonic — never reuse a number, even after deprecation
+- File names use kebab-case, ASCII only
+- "Accepted" means it's live in the codebase. "Proposed" means under discussion (rare for solo project but allowed)
+- Reference ADRs from code comments only when the *why* is non-obvious and the ADR is the canonical source

--- a/lib/services/CLAUDE.md
+++ b/lib/services/CLAUDE.md
@@ -1,6 +1,6 @@
 # Services Library — AI Reference
 
-15 pure-logic utility libraries extracted from managers for testability. All stateless (except TextUtils), no hardware dependencies, 100% test coverage.
+17 pure-logic utility libraries extracted from managers for testability. All stateless (except TextUtils), no hardware dependencies, 100% test coverage.
 
 ## Service Map
 
@@ -21,6 +21,8 @@
 | **PlaceholderUtils** | `{{key}}` template substitution via callback | Yes | `replacePlaceholdersWith(input, getValue)` |
 | **LayoutEngine** | Icon/text position: left, right, none layouts | Yes | `computeLayout()`, `layoutToString()`, `layoutFromString()` |
 | **FormatStringValidator** | Whitelist for user-supplied printf format strings (CWE-134 defense) | Yes | `isSafeSingleArgFormat(fmt)` |
+| **ResetReason** | Map ESP32 reset code (`esp_reset_reason_t`) to a short stable tag | Yes | `resetReasonToString(code)` |
+| **SignatureVerifier** | Phase 1 structural check for OTA signatures (see ADR 0005) | Yes | `isPlausibleRsa2048SignatureBase64()`, `buildSignatureUrl()` |
 
 ## Dependency Graph
 
@@ -78,6 +80,8 @@ Every service has dedicated tests in `test/test_native/`:
 | PlaceholderUtils | `test_placeholder_utils/` |
 | LayoutEngine | `test_layout_engine/` |
 | FormatStringValidator | `test_format_validator/` |
+| ResetReason | `test_reset_reason/` |
+| SignatureVerifier | `test_signature_verifier/` |
 
 Run all: `pio test -e native_test`
 


### PR DESCRIPTION
> **Stacked on top of #61 (feat/signed-ota-phase-1).** Retarget to \`main\` once #60 and #61 merge.

## Summary

Three logical commits, grouped here as a single PR. The branch finishes the documentation, tooling, and community-files work that has accumulated alongside the architecture changes. No production code is touched.

1. **\`docs(adr)\`** — \`adr/\` scaffolding (Michael Nygard format) + four foundational ADRs:
   - ADR 0001 — interface decoupling via \`lib/interfaces/\`
   - ADR 0002 — 3-class DisplayManager split
   - ADR 0003 — stateless services in \`lib/services/\`
   - ADR 0004 — Clean Code & Architecture as project standard
2. **\`chore(ai-tooling)\`** — three read-only PR-review sub-agents (\`pr-reviewer\`, \`embedded-cpp-reviewer\`, \`firmware-architecture-reviewer\`), \`clang-tidy\` advisory CI job (continue-on-error), five slash-command files refreshed, root \`CLAUDE.md\` Sub-agents + CodeGraph sections, \`.gitignore\` for \`.codegraph/\`, \`.vscode/extensions.json\` for shared editor recommendations.
3. **\`docs\`** — community files (SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md, .github/PULL_REQUEST_TEMPLATE.md), \`lib/services/CLAUDE.md\` services count synced 15→17, README intro rewritten from "community-driven fork" to "started as a fork, substantially rewritten" (matching the actual codebase state).

## Test plan

- [x] \`pio test -e native_test\` passes (590/590) — no code changes in this PR
- [x] \`pre-commit\` hooks: clang-format / cppcheck / end-of-file / conventional-commits all green on each commit
- [x] \`gh pr create\` template renders correctly (this PR is the first to use the new template structure)
- [ ] Manual proofread of CHANGELOG \`[Unreleased]\` entries before merge

## Binary size

N/A — docs and tooling only.

## Breaking changes

None.

## Documentation

This PR **is** the documentation update. Module-level CLAUDE.md sync for the two new services (ResetReason, SignatureVerifier) is included in the third commit.

## Notes for reviewer

- Each commit is independently meaningful; consider reviewing per-commit (\`gh pr diff 62 --commit ...\` or the GitHub UI "commits" tab).
- The CoC text is the verbatim Contributor Covenant 2.1, fetched from the official source via \`curl\`. Only the contact email is substituted.
- The ADRs were authored under the strict rule "documents only what is implemented" — they were reviewed against the actual codebase before commit (no aspirational claims).