### PR TITLE
fix: navigate to Time app when night mode blocks auto-transition

### DIFF
--- a/src/DisplayManager/DisplayManager.cpp
+++ b/src/DisplayManager/DisplayManager.cpp
@@ -266,7 +266,15 @@ void DisplayManager_::tick()
                 if (activePolicy_->overridesTextColor(col))
                     setTextColor(col);
                 if (activePolicy_->blocksAutoTransition())
+                {
                     setAutoTransition(false);
+                    // When auto-transition is blocked (e.g. night mode),
+                    // switch to the Time app so the display locks on the
+                    // clock screen rather than freezing on a random app.
+                    int timeIndex = findAppIndexByName("Time");
+                    if (timeIndex >= 0)
+                        ui->switchToApp(timeIndex);
+                }
             }
             else
             {
@@ -491,17 +499,23 @@ void DisplayManager_::gammaCorrection()
     {
         leds[i] = applyGamma_video(leds[i], gamma);
     }
-
     if (displayConfig.mirrorDisplay)
     {
         for (int y = 0; y < MATRIX_HEIGHT; y++)
         {
             for (int x = 0; x < MATRIX_WIDTH / 2; x++)
             {
-                int index1 = y * MATRIX_WIDTH + x;
-                int index2 = y * MATRIX_WIDTH + (MATRIX_WIDTH - x - 1);
-                std::swap(leds[index1], leds[index2]);
+                int left = y * MATRIX_WIDTH + x;
+                int right = y * MATRIX_WIDTH + (MATRIX_WIDTH - 1 - x);
+                CRGB temp = leds[left];
+                leds[left] = leds[right];
+                leds[right] = temp;
             }
         }
     }
+}
+
+void DisplayManager_::ResetCustomApps()
+{
+    resetAppTime = millis();
 }

--- a/src/DisplayManager/DisplayManager.cpp
+++ b/src/DisplayManager/DisplayManager.cpp
@@ -499,23 +499,17 @@ void DisplayManager_::gammaCorrection()
     {
         leds[i] = applyGamma_video(leds[i], gamma);
     }
+
     if (displayConfig.mirrorDisplay)
     {
         for (int y = 0; y < MATRIX_HEIGHT; y++)
         {
             for (int x = 0; x < MATRIX_WIDTH / 2; x++)
             {
-                int left = y * MATRIX_WIDTH + x;
-                int right = y * MATRIX_WIDTH + (MATRIX_WIDTH - 1 - x);
-                CRGB temp = leds[left];
-                leds[left] = leds[right];
-                leds[right] = temp;
+                int index1 = y * MATRIX_WIDTH + x;
+                int index2 = y * MATRIX_WIDTH + (MATRIX_WIDTH - x - 1);
+                std::swap(leds[index1], leds[index2]);
             }
         }
     }
-}
-
-void DisplayManager_::ResetCustomApps()
-{
-    resetAppTime = millis();
 }


### PR DESCRIPTION
## Bug Description

When night mode activates with **"Block auto-transition"** enabled, the display freezes on whatever app is currently shown (Date, Temperature, Battery, etc.) instead of locking on the clock screen. The expected behavior is for the display to show the **Time** app during locked night mode, since night mode is primarily a bedside clock feature.

## Root Cause

In `DisplayManager::tick()`, the policy activation edge only calls `setAutoTransition(false)` to disable cycling — it never navigates to the Time app:

```cpp
// Before (line 268-269)
if (activePolicy_->blocksAutoTransition())
    setAutoTransition(false);
```

The display simply stays on whichever app was active when the night-mode window opened.

## Fix

Added a `findAppIndexByName("Time")` lookup followed by `ui->switchToApp(timeIndex)` when `blocksAutoTransition()` is true, so the display immediately switches to the Time app before locking auto-transition.

```cpp
// After
if (activePolicy_->blocksAutoTransition())
{
    setAutoTransition(false);
    int timeIndex = findAppIndexByName("Time");
    if (timeIndex >= 0)
        ui->switchToApp(timeIndex);
}
```

| | |
|---|---|
| **Files changed** | 1 (`src/DisplayManager/DisplayManager.cpp`) |
| **Lines added** | +8 (4 logic + braces + comment) |
| **New dependencies** | None — `Apps.h` and `MatrixDisplayUi` already included |

## Edge Cases

| Scenario | Behavior |
|---|---|
| Time app hidden (`showTime = false`) | `findAppIndexByName` returns -1, `switchToApp` skipped — no crash |
| Already on Time app | `switchToApp` returns false when `app == currentApp` — no-op |
| Night mode ends | Unchanged — restores `autoTransition` to user's setting |
| `nightBlockTransition` disabled | Branch never entered — no effect |

## How to Verify

1. Enable night mode with a time window crossing the current time (e.g. start = now - 1 min, end = now + 10 min)
2. Enable "Block auto-transition" in night mode settings
3. Make sure at least 2 apps are active (Time + Date)
4. Navigate to a non-Time app (e.g. Date) and wait for night mode to activate
5. Display should switch to Time app and lock there

## Risk Assessment

**Low** — 4-line addition on the existing policy-activation edge path. Uses `findAppIndexByName()` and `ui->switchToApp()` which are battle-tested elsewhere in the codebase. No new allocations, no timing changes, no API surface changes.